### PR TITLE
Support prototyping strings, variables, operators and expressions

### DIFF
--- a/utils/block_proto/app.js
+++ b/utils/block_proto/app.js
@@ -32,17 +32,20 @@ import {getBlockList, render} from './blocks.js';
 const argv = yargs(hideBin(process.argv)).options({
   'block': {
     alias: 'b',
+    type: 'string',
     describe: 'The kind of the main block to output.',
     demandOption: true,
     choices: getBlockList(),
   },
   'config': {
     alias: 'c',
+    type: 'string',
     describe: 'Optional config string for rendering blocks.',
     demandOption: false,
   },
   'output': {
     alias: 'o',
+    type: 'string',
     describe: 'The output SVG file path.',
     demandOption: false,
   },

--- a/utils/block_proto/app.js
+++ b/utils/block_proto/app.js
@@ -19,11 +19,16 @@
  * @fileoverview The main entry of the block prototype maker.
  */
 
+// @ts-check
+
 import fs from 'fs';
 import yargs from 'yargs';
 import {hideBin} from 'yargs/helpers';
 import {getBlockList, render} from './blocks.js';
 
+/**
+ * @type {Object}
+ */
 const argv = yargs(hideBin(process.argv)).options({
   'block': {
     alias: 'b',
@@ -43,7 +48,7 @@ const argv = yargs(hideBin(process.argv)).options({
   },
 }).argv;
 
-const svg = render(argv.block, argv.config);
+const svg = render(argv.block, argv.config || null);
 if (argv.output) {
   fs.writeFileSync(argv.output, svg);
 } else {

--- a/utils/block_proto/block_utils.js
+++ b/utils/block_proto/block_utils.js
@@ -44,14 +44,14 @@ export function splitListItems(listString, blockDefs, validOperators) {
     if (!itemString) {
       break;
     }
-    if (itemString.match(/^[0-9.eE\-]+$/)) {
-      items.push({
-        blockDef: blockDefs.number,
-        config: itemString,
-      });
-    } else if (validOperators.includes(itemString)) {
+    if (validOperators.includes(itemString)) {
       items.push({
         blockDef: blockDefs.operator,
+        config: itemString,
+      });
+    } else if (itemString.match(/^[0-9.eE\-]+$/)) {
+      items.push({
+        blockDef: blockDefs.number,
         config: itemString,
       });
     } else if (itemString.match(/^[a-zA-Z_]+$/)) {

--- a/utils/block_proto/block_utils.js
+++ b/utils/block_proto/block_utils.js
@@ -34,19 +34,23 @@
  * checker is required here.
  * @param {string} listString The comma separated list string.
  * @param {!Object} blockDefs The definition of all blocks.
- * @param {!Array<string>} validOperators The list of valid operators.
  * @return {!Array<Object>} An array of tagged items.
  */
-export function splitListItems(listString, blockDefs, validOperators) {
+export function splitListItems(listString, blockDefs) {
   const itemStrings = listString.split(',');
   const items = [];
   for (const itemString of itemStrings) {
     if (!itemString) {
       break;
     }
-    if (validOperators.includes(itemString)) {
+    if (blockDefs.operator.validValues.includes(itemString)) {
       items.push({
         blockDef: blockDefs.operator,
+        config: itemString,
+      });
+    } else if (blockDefs.parentheses.validValues.includes(itemString)) {
+      items.push({
+        blockDef: blockDefs.parentheses,
         config: itemString,
       });
     } else if (itemString.match(/^[0-9.eE\-]+$/)) {

--- a/utils/block_proto/block_utils.js
+++ b/utils/block_proto/block_utils.js
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2021 The Aha001 Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Utilities for rendering blocks.
+ */
+
+// @ts-check
+
+/**
+ * Splits a comma separated list string into tagged items.
+ *
+ * The input list string can be:
+ *
+ *  - An expression, e.g., '(,3.14,+,2.71,),&gt;=,counter'.
+ *  - A list literal, e.g., '1,2,3,4,5'.
+ *
+ * As this is an internal prototype drawing utility, we assume the input list
+ * string is correctly built and formatted. Neither syntax parser nor semantic
+ * checker is required here.
+ * @param {string} listString The comma separated list string.
+ * @param {!Object} blockDefs The definition of all blocks.
+ * @param {!Array<string>} validOperators The list of valid operators.
+ * @return {!Array<Object>} An array of tagged items.
+ */
+export function splitListItems(listString, blockDefs, validOperators) {
+  const itemStrings = listString.split(',');
+  const items = [];
+  for (const itemString of itemStrings) {
+    if (!itemString) {
+      break;
+    }
+    if (itemString.match(/^[0-9.eE\-]+$/)) {
+      items.push({
+        blockDef: blockDefs.number,
+        config: itemString,
+      });
+    } else if (validOperators.includes(itemString)) {
+      items.push({
+        blockDef: blockDefs.operator,
+        config: itemString,
+      });
+    } else if (itemString.match(/^[a-zA-Z_]+$/)) {
+      items.push({
+        blockDef: blockDefs.variable,
+        config: itemString,
+      });
+    } else {
+      throw new Error('Not supported item in lists: ' + itemString);
+    }
+  }
+  if (items.length <= 0) {
+    throw new Error('Invalid list string: ' + listString);
+  }
+  return items;
+}

--- a/utils/block_proto/block_utils.js
+++ b/utils/block_proto/block_utils.js
@@ -64,7 +64,7 @@ export function splitListItems(listString, blockDefs) {
         config: itemString,
       });
     } else {
-      throw new Error('Not supported item in lists: ' + itemString);
+      throw new Error('Not supported item in the list: ' + itemString);
     }
   }
   if (items.length <= 0) {

--- a/utils/block_proto/blocks.js
+++ b/utils/block_proto/blocks.js
@@ -214,7 +214,7 @@ function renderOctagonToken(draw, blockDef, config, offset) {
         [shapeOffset.x, shapeOffset.y + shapeHeight - GLOBAL_DEFS.rectRadius],
       ])
       .fill(blockDef.background)
-      .move(GLOBAL_DEFS.margin, GLOBAL_DEFS.margin);
+      .move(shapeOffset.x, shapeOffset.y);
 
   renderCenterText(draw, nameString, shapeWidth, shapeHeight, blockDef.color,
       shapeOffset);

--- a/utils/block_proto/blocks.js
+++ b/utils/block_proto/blocks.js
@@ -57,6 +57,12 @@ const BLOCK_DEFS = {
     defaultValue: '3.14',
     renderer: renderRoundRectValue,
   },
+  operator: {
+    background: '#999',
+    color: '#fff',
+    defaultValue: '+',
+    renderer: renderOctagonToken,
+  },
   string: {
     background: '#963',
     color: '#fff',
@@ -64,6 +70,12 @@ const BLOCK_DEFS = {
     delimiterColor: '#fc0',
     defaultValue: 'Hello',
     renderer: renderRoundRectValue,
+  },
+  variable: {
+    background: '#39f',
+    color: '#fff',
+    defaultValue: 'counter',
+    renderer: renderOctagonToken,
   },
 };
 
@@ -116,7 +128,7 @@ function renderCenterText(draw, text, shapeWidth, shapeHeight, color, offset) {
 }
 
 /**
- * Renders a number of string value in a round rectangle shape.
+ * Renders a number or string value in a round rectangle shape.
  * @param {!Object} draw The svgjs draw object.
  * @param {!Object} blockDef The definition of the block kind.
  * @param {?string} config The config string.
@@ -137,16 +149,16 @@ function renderRoundRectValue(draw, blockDef, config, offset) {
       textLength * GLOBAL_DEFS.fontCharWidth;
   const shapeHeight = 2 * GLOBAL_DEFS.padding + GLOBAL_DEFS.fontCharHeight;
 
-  const blockOffset = offset ||
+  const shapeOffset = offset ||
     new svgjs.Point(GLOBAL_DEFS.margin, GLOBAL_DEFS.margin);
 
   draw.rect(shapeWidth, shapeHeight)
       .fill(blockDef.background)
       .radius(GLOBAL_DEFS.rectRadius)
-      .move(blockOffset.x, blockOffset.y);
+      .move(shapeOffset.x, shapeOffset.y);
 
   renderCenterText(draw, valueString, shapeWidth, shapeHeight, blockDef.color,
-      blockOffset);
+      shapeOffset);
 
   if (blockDef.delimiter) {
     // Iterates for the left delimiter and the right delimiter.
@@ -159,10 +171,53 @@ function renderRoundRectValue(draw, blockDef, config, offset) {
       draw.text(blockDef.delimiter)
           .font(GLOBAL_DEFS.font)
           .fill(blockDef.delimiterColor)
-          .move(blockOffset.x + textAnchorX,
-              blockOffset.y + textAnchorY);
+          .move(shapeOffset.x + textAnchorX,
+              shapeOffset.y + textAnchorY);
     }
   }
+
+  return {width: shapeWidth, height: shapeHeight};
+}
+
+/**
+ * Renders a variable or operator token in an octagon block.
+ * @param {!Object} draw The svgjs draw object.
+ * @param {!Object} blockDef The definition of the block kind.
+ * @param {?string} config The config string.
+ * @param {?svgjs.Point} offset The offset of the block. If it is null, the
+ *     block is the main block and will be positioned to the center of the SVG
+ *     canvas.
+ * @return {{width: number, height: number}} The calculated size of the block.
+ *     Margins are not included.
+ */
+function renderOctagonToken(draw, blockDef, config, offset) {
+  const nameString = config ? config : blockDef.defaultValue;
+  const textLength = nameString.length;
+  const shapeWidth = 2 * GLOBAL_DEFS.padding +
+    textLength * GLOBAL_DEFS.fontCharWidth;
+  const shapeHeight = 2 * GLOBAL_DEFS.padding + GLOBAL_DEFS.fontCharHeight;
+
+  const shapeOffset = offset ||
+      new svgjs.Point(GLOBAL_DEFS.margin, GLOBAL_DEFS.margin);
+
+  draw.polygon()
+      .plot([
+        [shapeOffset.x, shapeOffset.y + GLOBAL_DEFS.rectRadius],
+        [shapeOffset.x + GLOBAL_DEFS.rectRadius, shapeOffset.y],
+        [shapeOffset.x + shapeWidth - GLOBAL_DEFS.rectRadius, shapeOffset.y],
+        [shapeOffset.x + shapeWidth, shapeOffset.y + GLOBAL_DEFS.rectRadius],
+        [shapeOffset.x + shapeWidth,
+          shapeOffset.y + shapeHeight - GLOBAL_DEFS.rectRadius],
+        [shapeOffset.x + shapeWidth - GLOBAL_DEFS.rectRadius,
+          shapeOffset.y + shapeHeight],
+        [shapeOffset.x + GLOBAL_DEFS.rectRadius, shapeOffset.y + shapeHeight],
+        [shapeOffset.x, shapeOffset.y + shapeHeight - GLOBAL_DEFS.rectRadius],
+      ])
+      .fill(blockDef.background)
+      .move(GLOBAL_DEFS.margin, GLOBAL_DEFS.margin);
+
+  renderCenterText(draw, nameString, shapeWidth, shapeHeight, blockDef.color,
+      shapeOffset);
 
   return {width: shapeWidth, height: shapeHeight};
 }

--- a/utils/block_proto/blocks.js
+++ b/utils/block_proto/blocks.js
@@ -65,10 +65,24 @@ export const BLOCK_DEFS = {
     renderer: renderRoundRectValue,
   },
   operator: {
-    background: '#999',
-    color: '#fff',
+    background: '#9cf',
+    color: '#000',
     defaultValue: '+',
     renderer: renderOctagonToken,
+    validValues: [
+      '+', '-', '*', '×', '/', '÷', '^',
+      '==', '!=', '>', '>=', '<', '<=',
+      'and', 'or', 'not',
+    ],
+  },
+  parentheses: {
+    background: '#ff9',
+    color: '#000',
+    defaultValue: '(',
+    renderer: renderOctagonToken,
+    validValues: [
+      '(', ')',
+    ],
   },
   string: {
     background: '#963',
@@ -85,16 +99,6 @@ export const BLOCK_DEFS = {
     renderer: renderOctagonToken,
   },
 };
-
-/**
- * @const {Array<string>}
- */
-export const OPERATORS = [
-  '+', '-', '*', '×', '/', '÷', '^',
-  '==', '!=', '>', '>=', '<', '<=',
-  'and', 'or', 'not',
-  '(', ')',
-];
 
 /**
  * Returns an array of all block kinds.
@@ -249,7 +253,7 @@ function renderOctagonToken(draw, blockDef, config, offset) {
  */
 function renderExpressionContainer(draw, blockDef, config, offset) {
   const expressionString = config || blockDef.defaultValue;
-  const children = splitListItems(expressionString, BLOCK_DEFS, OPERATORS);
+  const children = splitListItems(expressionString, BLOCK_DEFS);
   let shapeWidth = 0;
   let shapeHeight = 0;
   const shapeOffset = offset ||

--- a/utils/block_proto/blocks.js
+++ b/utils/block_proto/blocks.js
@@ -19,6 +19,9 @@
  * @fileoverview Utilities to define and render blocks.
  */
 
+// @ts-check
+
+// @ts-ignore
 import {createSVGWindow} from 'svgdom';
 import svgjs from '@svgdotjs/svg.js';
 

--- a/utils/block_proto/blocks.js
+++ b/utils/block_proto/blocks.js
@@ -23,7 +23,8 @@ import {createSVGWindow} from 'svgdom';
 import svgjs from '@svgdotjs/svg.js';
 
 /**
- * @const {Object}
+ * The settings for all blocks.
+ * @const {!Object}
  */
 const GLOBAL_DEFS = {
   font: {
@@ -41,7 +42,8 @@ const GLOBAL_DEFS = {
 };
 
 /**
- * @const {Object}
+ * The block definitions.
+ * @const {!Object}
  */
 const BLOCK_DEFS = {
   number: {
@@ -53,7 +55,7 @@ const BLOCK_DEFS = {
 
 /**
  * Returns an array of all block kinds.
- * @return {Array}
+ * @return {!Array}
  */
 export function getBlockList() {
   return Object.keys(BLOCK_DEFS);
@@ -62,7 +64,7 @@ export function getBlockList() {
 /**
  * Renders a main block with or without its children blocks.
  * @param {string} block The kind of the main block.
- * @param {string?} config The config string.
+ * @param {?string} config The config string.
  * @return {string} The rendered SVG string.
  */
 export function render(block, config) {
@@ -79,9 +81,9 @@ export function render(block, config) {
 
 /**
  * Renders a number value block.
- * @param {Object} draw The svgjs draw object.
- * @param {Object} defs The definition of the main block kind.
- * @param {string?} config The config string.
+ * @param {!Object} draw The svgjs draw object.
+ * @param {!Object} defs The definition of the main block kind.
+ * @param {?string} config The config string.
  */
 function renderNumber(draw, defs, config) {
   const value = '3.14';

--- a/utils/block_proto/blocks.js
+++ b/utils/block_proto/blocks.js
@@ -266,7 +266,6 @@ function renderExpressionContainer(draw, blockDef, config, offset) {
   let childOffsetX = shapeOffset.x + GLOBAL_DEFS.padding;
   const childOffsetY = shapeOffset.y + GLOBAL_DEFS.padding;
   shapeWidth = GLOBAL_DEFS.padding;
-  shapeHeight = 2 * GLOBAL_DEFS.padding;
   let highestChild = 0;
   for (const child of children) {
     const childShapeSize =

--- a/utils/block_proto/blocks.js
+++ b/utils/block_proto/blocks.js
@@ -120,8 +120,11 @@ export function render(block, config) {
   const draw = svgjs.SVG(); // eslint-disable-line
 
   if (block in BLOCK_DEFS) {
-    const blockSize =
-        BLOCK_DEFS[block].renderer(draw, BLOCK_DEFS[block], config, null);
+    const blockDef = BLOCK_DEFS[block];
+    if (blockDef.validValues && !blockDef.validValues.includes(config)) {
+      config = null;
+    }
+    const blockSize = blockDef.renderer(draw, BLOCK_DEFS[block], config, null);
     draw.size(blockSize.width + 2 * GLOBAL_DEFS.margin,
         blockSize.height + 2 * GLOBAL_DEFS.margin);
   }

--- a/utils/block_proto/blocks.js
+++ b/utils/block_proto/blocks.js
@@ -48,7 +48,7 @@ const GLOBAL_DEFS = {
  * The block definitions.
  * @const {!Object}
  */
-const BLOCK_DEFS = {
+export const BLOCK_DEFS = {
   number: {
     background: '#690',
     color: '#fff',
@@ -78,6 +78,16 @@ const BLOCK_DEFS = {
     renderer: renderOctagonToken,
   },
 };
+
+/**
+ * @const {Array<string>}
+ */
+export const OPERATORS = [
+  '+', '-', '×', '÷', '^',
+  '==', '!=', '>', '>=', '<', '<=',
+  'and', 'or', 'not',
+  '(', ')',
+];
 
 /**
  * Returns an array of all block kinds.
@@ -144,11 +154,9 @@ function renderRoundRectValue(draw, blockDef, config, offset) {
   if (blockDef.delimiter) {
     textLength += 2;
   }
-
   const shapeWidth = 2 * GLOBAL_DEFS.padding +
       textLength * GLOBAL_DEFS.fontCharWidth;
   const shapeHeight = 2 * GLOBAL_DEFS.padding + GLOBAL_DEFS.fontCharHeight;
-
   const shapeOffset = offset ||
     new svgjs.Point(GLOBAL_DEFS.margin, GLOBAL_DEFS.margin);
 
@@ -196,7 +204,6 @@ function renderOctagonToken(draw, blockDef, config, offset) {
   const shapeWidth = 2 * GLOBAL_DEFS.padding +
     textLength * GLOBAL_DEFS.fontCharWidth;
   const shapeHeight = 2 * GLOBAL_DEFS.padding + GLOBAL_DEFS.fontCharHeight;
-
   const shapeOffset = offset ||
       new svgjs.Point(GLOBAL_DEFS.margin, GLOBAL_DEFS.margin);
 

--- a/utils/block_proto/test/block_utils_test.js
+++ b/utils/block_proto/test/block_utils_test.js
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2021 The Aha001 Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Unittests for blocks.js.
+ */
+
+// @ts-check
+
+import assert from 'assert';
+import {splitListItems} from '../block_utils.js';
+import {BLOCK_DEFS, OPERATORS} from '../blocks.js';
+
+describe('splitListItems', function() {
+  it('checkSplit', function() {
+    assert.throws(() => splitListItems('', BLOCK_DEFS, OPERATORS));
+
+    let items = splitListItems('a,b,c', BLOCK_DEFS, OPERATORS);
+
+    assert.strictEqual(items.length, 3);
+    assert.strictEqual(items[0].config, 'a');
+    assert.strictEqual(items[0].blockDef.background, '#39f');
+    assert.strictEqual(items[1].config, 'b');
+    assert.strictEqual(items[1].blockDef.background, '#39f');
+    assert.strictEqual(items[2].config, 'c');
+    assert.strictEqual(items[2].blockDef.background, '#39f');
+
+    items = splitListItems('(,3.14,+,2.71,),>=,counter',
+        BLOCK_DEFS, OPERATORS);
+    assert.strictEqual(items.length, 7);
+    assert.strictEqual(items[0].config, '(');
+    assert.strictEqual(items[0].blockDef.background, '#999');
+    assert.strictEqual(items[1].config, '3.14');
+    assert.strictEqual(items[1].blockDef.background, '#690');
+    assert.strictEqual(items[6].config, 'counter');
+    assert.strictEqual(items[6].blockDef.background, '#39f');
+  });
+});

--- a/utils/block_proto/test/block_utils_test.js
+++ b/utils/block_proto/test/block_utils_test.js
@@ -23,13 +23,13 @@
 
 import assert from 'assert';
 import {splitListItems} from '../block_utils.js';
-import {BLOCK_DEFS, OPERATORS} from '../blocks.js';
+import {BLOCK_DEFS} from '../blocks.js';
 
 describe('splitListItems', function() {
   it('checkSplit', function() {
-    assert.throws(() => splitListItems('', BLOCK_DEFS, OPERATORS));
+    assert.throws(() => splitListItems('', BLOCK_DEFS));
 
-    let items = splitListItems('a,b,c', BLOCK_DEFS, OPERATORS);
+    let items = splitListItems('a,b,c', BLOCK_DEFS);
 
     assert.strictEqual(items.length, 3);
     assert.strictEqual(items[0].config, 'a');
@@ -39,13 +39,14 @@ describe('splitListItems', function() {
     assert.strictEqual(items[2].config, 'c');
     assert.strictEqual(items[2].blockDef.background, '#39f');
 
-    items = splitListItems('(,3.14,+,2.71,),>=,counter',
-        BLOCK_DEFS, OPERATORS);
+    items = splitListItems('(,3.14,+,2.71,),>=,counter', BLOCK_DEFS);
     assert.strictEqual(items.length, 7);
     assert.strictEqual(items[0].config, '(');
-    assert.strictEqual(items[0].blockDef.background, '#999');
+    assert.strictEqual(items[0].blockDef.background, '#ff9');
     assert.strictEqual(items[1].config, '3.14');
     assert.strictEqual(items[1].blockDef.background, '#690');
+    assert.strictEqual(items[2].config, '+');
+    assert.strictEqual(items[2].blockDef.background, '#9cf');
     assert.strictEqual(items[6].config, 'counter');
     assert.strictEqual(items[6].blockDef.background, '#39f');
   });

--- a/utils/block_proto/test/blocks_test.js
+++ b/utils/block_proto/test/blocks_test.js
@@ -40,7 +40,15 @@ describe('renderRoundRectValue', function() {
     // On the other hand, string blocks always have the delimiter color string.
     assert.match(render('string', null), /#ffcc00/);
   });
-  it('checkUserConfig', function() {
+});
+
+describe('renderWithUserConfig', function() {
+  it('validUserConfig', function() {
     assert.match(render('string', '1234567890'), /1234567890/);
+  });
+  it('invalidUserConfig', function() {
+    const svg = render('operator', '1234567890');
+    assert.doesNotMatch(svg, /1234567890/);
+    assert.match(svg, /\+/);
   });
 });

--- a/utils/block_proto/test/blocks_test.js
+++ b/utils/block_proto/test/blocks_test.js
@@ -1,3 +1,24 @@
+/**
+ * @license
+ * Copyright 2021 The Aha001 Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Unittests for blocks.js.
+ */
+
 import assert from 'assert';
 import {getBlockList, render} from '../blocks.js';
 

--- a/utils/block_proto/test/blocks_test.js
+++ b/utils/block_proto/test/blocks_test.js
@@ -19,6 +19,8 @@
  * @fileoverview Unittests for blocks.js.
  */
 
+// @ts-check
+
 import assert from 'assert';
 import {getBlockList, render} from '../blocks.js';
 
@@ -30,6 +32,6 @@ describe('getBlockList', function() {
 
 describe('render', function() {
   it('checkSVG', function() {
-    assert(render('number').match('<svg.*</svg>'));
+    assert(render('number', null).match('<svg.*</svg>'));
   });
 });

--- a/utils/block_proto/test/blocks_test.js
+++ b/utils/block_proto/test/blocks_test.js
@@ -26,12 +26,21 @@ import {getBlockList, render} from '../blocks.js';
 
 describe('getBlockList', function() {
   it('checkNumber', function() {
-    assert.strictEqual(getBlockList().length, 1);
+    assert.strictEqual(getBlockList().length, 2);
   });
 });
 
-describe('render', function() {
+describe('renderRoundRectValue', function() {
   it('checkSVG', function() {
-    assert(render('number', null).match('<svg.*</svg>'));
+    assert.match(render('number', null), /<svg.*<\/svg>/);
+  });
+  it('checkNumberAndString', function() {
+    // The SVG code of Number blocks must not contain string delimiters.
+    assert.doesNotMatch(render('number', null), /#ffcc00/);
+    // On the other hand, string blocks always have the delimiter color string.
+    assert.match(render('string', null), /#ffcc00/);
+  });
+  it('checkUserConfig', function() {
+    assert.match(render('string', '1234567890'), /1234567890/);
   });
 });

--- a/utils/block_proto/test/blocks_test.js
+++ b/utils/block_proto/test/blocks_test.js
@@ -26,7 +26,7 @@ import {getBlockList, render} from '../blocks.js';
 
 describe('getBlockList', function() {
   it('checkNumber', function() {
-    assert.strictEqual(getBlockList().length, 2);
+    assert.strictEqual(getBlockList().length, 4);
   });
 });
 

--- a/utils/block_proto/test/blocks_test.js
+++ b/utils/block_proto/test/blocks_test.js
@@ -26,7 +26,7 @@ import {getBlockList, render} from '../blocks.js';
 
 describe('getBlockList', function() {
   it('checkNumber', function() {
-    assert.strictEqual(getBlockList().length, 4);
+    assert.strictEqual(getBlockList().length, 5);
   });
 });
 

--- a/utils/block_proto/test/blocks_test.js
+++ b/utils/block_proto/test/blocks_test.js
@@ -26,7 +26,7 @@ import {getBlockList, render} from '../blocks.js';
 
 describe('getBlockList', function() {
   it('checkNumber', function() {
-    assert.strictEqual(getBlockList().length, 5);
+    assert.strictEqual(getBlockList().length, 6);
   });
 });
 


### PR DESCRIPTION
Example commands:

1) Generate a simple string:

node . -b string -o out.svg -c 'Hello, World!'

![b](https://user-images.githubusercontent.com/5819968/122644635-cd785d00-d148-11eb-9371-59af6e29487a.png)

2) Generate an expression that contains a number of number values, operators and variables:

node . -b expression -o out.svg -c '130,÷,num,-,(,factor,^,7e4,+,delta,),×,-3.1415926,>=,7,and,1,==,2'

![a](https://user-images.githubusercontent.com/5819968/122644633-cc473000-d148-11eb-97ee-05e59abb4bda.png)