### PR TITLE
Support prototyping simple statements 

### DIFF
--- a/utils/block_proto/block_utils.js
+++ b/utils/block_proto/block_utils.js
@@ -40,35 +40,55 @@ export function splitListItems(listString, blockDefs) {
   const itemStrings = listString.split(',');
   const items = [];
   for (const itemString of itemStrings) {
-    if (!itemString) {
-      break;
-    }
-    if (blockDefs.operator.validValues.includes(itemString)) {
+    if (itemString) {
       items.push({
-        blockDef: blockDefs.operator,
+        blockDef: getBlockDefPerConfigString(itemString, blockDefs),
         config: itemString,
       });
-    } else if (blockDefs.parentheses.validValues.includes(itemString)) {
-      items.push({
-        blockDef: blockDefs.parentheses,
-        config: itemString,
-      });
-    } else if (itemString.match(/^[0-9.eE\-]+$/)) {
-      items.push({
-        blockDef: blockDefs.number,
-        config: itemString,
-      });
-    } else if (itemString.match(/^[a-zA-Z_]+$/)) {
-      items.push({
-        blockDef: blockDefs.variable,
-        config: itemString,
-      });
-    } else {
-      throw new Error('Not supported item in the list: ' + itemString);
     }
   }
   if (items.length <= 0) {
     throw new Error('Invalid list string: ' + listString);
   }
   return items;
+}
+
+/**
+ * Splits a '|' separated string into input items for filling a statement.
+ *
+ * As this is an internal prototype drawing utility, we assume the input string
+ * is correctly built and formatted. Neither syntax parser nor semantic checker
+ * is required here.
+ * @param {string} inputString The string of inputs.
+ * @return {!Array<string>} An array of parsed input items.
+ */
+export function splitInputItems(inputString) {
+  const items = inputString.split('|').filter((itemString) => itemString);
+  if (items.length <= 0) {
+    throw new Error('Invalid input string: ' + inputString);
+  }
+  return items;
+}
+
+/**
+ * Determines the block type per a config string, and returns the corresponding
+ * block definition.
+ * @param {string} config
+ * @param {!Object} blockDefs The definition of all blocks.
+ * @return {!Object} The definition of the block.
+ */
+export function getBlockDefPerConfigString(config, blockDefs) {
+  if (config.includes(',')) {
+    return blockDefs.expression;
+  } else if (blockDefs.operator.validValues.includes(config)) {
+    return blockDefs.operator;
+  } else if (blockDefs.parentheses.validValues.includes(config)) {
+    return blockDefs.parentheses;
+  } else if (config.match(/^[0-9.eE\-]+$/)) {
+    return blockDefs.number;
+  } else if (config.match(/^[a-zA-Z_]+$/)) {
+    return blockDefs.variable;
+  } else {
+    throw new Error('Invalid config: ' + config);
+  }
 }

--- a/utils/block_proto/block_utils.js
+++ b/utils/block_proto/block_utils.js
@@ -26,7 +26,7 @@
  *
  * The input list string can be:
  *
- *  - An expression, e.g., '(,3.14,+,2.71,),&gt;=,counter'.
+ *  - An expression, e.g., '(,3.14,+,2.71,),>=,counter'.
  *  - A list literal, e.g., '1,2,3,4,5'.
  *
  * As this is an internal prototype drawing utility, we assume the input list

--- a/utils/block_proto/blocks.js
+++ b/utils/block_proto/blocks.js
@@ -31,6 +31,20 @@ import {splitListItems} from './block_utils.js';
  * @const {!Object}
  */
 const GLOBAL_DEFS = {
+  bgColors: {
+    expression: '#cc6',
+    number: '#690',
+    operator: '#9cf',
+    parentheses: '#ff9',
+    statement: '#9cf',
+    string: '#963',
+    variable: '#39f',
+  },
+  colors: {
+    dark: '#000',
+    delimiter: '#fc0',
+    light: '#fff',
+  },
   font: {
     family: 'Courier',
     size: '14px',
@@ -51,22 +65,20 @@ const GLOBAL_DEFS = {
  */
 export const BLOCK_DEFS = {
   expression: {
-    background: '#cc6',
-    color: '#fff',
+    background: GLOBAL_DEFS.bgColors.expression,
     defaultValue: 'a,+,b',
     renderer: renderExpressionContainer,
   },
   number: {
-    background: '#690',
-    color: '#fff',
+    background: GLOBAL_DEFS.bgColors.number,
+    color: GLOBAL_DEFS.colors.light,
     delimiter: null,
-    delimiterColor: null,
     defaultValue: '3.14',
     renderer: renderRoundRectValue,
   },
   operator: {
-    background: '#9cf',
-    color: '#000',
+    background: GLOBAL_DEFS.bgColors.operator,
+    color: GLOBAL_DEFS.colors.dark,
     defaultValue: '+',
     renderer: renderOctagonToken,
     validValues: [
@@ -76,8 +88,8 @@ export const BLOCK_DEFS = {
     ],
   },
   parentheses: {
-    background: '#ff9',
-    color: '#000',
+    background: GLOBAL_DEFS.bgColors.parentheses,
+    color: GLOBAL_DEFS.colors.dark,
     defaultValue: '(',
     renderer: renderOctagonToken,
     validValues: [
@@ -85,16 +97,16 @@ export const BLOCK_DEFS = {
     ],
   },
   string: {
-    background: '#963',
-    color: '#fff',
+    background: GLOBAL_DEFS.bgColors.string,
+    color: GLOBAL_DEFS.colors.light,
     delimiter: '"',
-    delimiterColor: '#fc0',
+    delimiterColor: GLOBAL_DEFS.colors.delimiter,
     defaultValue: 'Hello',
     renderer: renderRoundRectValue,
   },
   variable: {
-    background: '#39f',
-    color: '#fff',
+    background: GLOBAL_DEFS.bgColors.variable,
+    color: GLOBAL_DEFS.colors.light,
     defaultValue: 'counter',
     renderer: renderOctagonToken,
   },

--- a/utils/block_proto/test/block_utils_test.js
+++ b/utils/block_proto/test/block_utils_test.js
@@ -22,32 +22,67 @@
 // @ts-check
 
 import assert from 'assert';
-import {splitListItems} from '../block_utils.js';
+import * as utils from '../block_utils.js';
 import {BLOCK_DEFS} from '../blocks.js';
 
 describe('splitListItems', function() {
   it('checkSplit', function() {
-    assert.throws(() => splitListItems('', BLOCK_DEFS));
+    assert.throws(() => utils.splitListItems('', BLOCK_DEFS));
 
-    let items = splitListItems('a,b,c', BLOCK_DEFS);
+    let items = utils.splitListItems('a,b,c', BLOCK_DEFS);
 
     assert.strictEqual(items.length, 3);
     assert.strictEqual(items[0].config, 'a');
-    assert.strictEqual(items[0].blockDef.background, '#39f');
+    assert.strictEqual(items[0].blockDef.background,
+        BLOCK_DEFS.variable.background);
     assert.strictEqual(items[1].config, 'b');
-    assert.strictEqual(items[1].blockDef.background, '#39f');
+    assert.strictEqual(items[1].blockDef.background,
+        BLOCK_DEFS.variable.background);
     assert.strictEqual(items[2].config, 'c');
-    assert.strictEqual(items[2].blockDef.background, '#39f');
+    assert.strictEqual(items[2].blockDef.background,
+        BLOCK_DEFS.variable.background);
 
-    items = splitListItems('(,3.14,+,2.71,),>=,counter', BLOCK_DEFS);
+    items = utils.splitListItems('(,3.14,+,2.71,),>=,counter', BLOCK_DEFS);
     assert.strictEqual(items.length, 7);
     assert.strictEqual(items[0].config, '(');
-    assert.strictEqual(items[0].blockDef.background, '#ff9');
+    assert.strictEqual(items[0].blockDef.background,
+        BLOCK_DEFS.parentheses.background);
     assert.strictEqual(items[1].config, '3.14');
-    assert.strictEqual(items[1].blockDef.background, '#690');
+    assert.strictEqual(items[1].blockDef.background,
+        BLOCK_DEFS.number.background);
     assert.strictEqual(items[2].config, '+');
-    assert.strictEqual(items[2].blockDef.background, '#9cf');
+    assert.strictEqual(items[2].blockDef.background,
+        BLOCK_DEFS.operator.background);
     assert.strictEqual(items[6].config, 'counter');
-    assert.strictEqual(items[6].blockDef.background, '#39f');
+    assert.strictEqual(items[6].blockDef.background,
+        BLOCK_DEFS.variable.background);
+  });
+});
+
+describe('splitInputItems', function() {
+  it('checkSplit', function() {
+    assert.throws(() => utils.splitInputItems(''));
+    assert.throws(() => utils.splitInputItems('|'));
+
+    const items = utils.splitInputItems('a|b|c');
+    assert.strictEqual(items.length, 3);
+    assert.strictEqual(items[0], 'a');
+    assert.strictEqual(items[1], 'b');
+    assert.strictEqual(items[2], 'c');
+  });
+});
+
+describe('getBlockDefPerConfigString', function() {
+  it('checkTypes', function() {
+    let blockDef = utils.getBlockDefPerConfigString('1,+,2', BLOCK_DEFS);
+    assert.strictEqual(blockDef.background, BLOCK_DEFS.expression.background);
+    blockDef = utils.getBlockDefPerConfigString('==', BLOCK_DEFS);
+    assert.strictEqual(blockDef.background, BLOCK_DEFS.operator.background);
+    blockDef = utils.getBlockDefPerConfigString(')', BLOCK_DEFS);
+    assert.strictEqual(blockDef.background, BLOCK_DEFS.parentheses.background);
+    blockDef = utils.getBlockDefPerConfigString('-3.14e0', BLOCK_DEFS);
+    assert.strictEqual(blockDef.background, BLOCK_DEFS.number.background);
+    blockDef = utils.getBlockDefPerConfigString('foo', BLOCK_DEFS);
+    assert.strictEqual(blockDef.background, BLOCK_DEFS.variable.background);
   });
 });

--- a/utils/block_proto/test/blocks_test.js
+++ b/utils/block_proto/test/blocks_test.js
@@ -26,7 +26,7 @@ import {getBlockList, render} from '../blocks.js';
 
 describe('getBlockList', function() {
   it('checkNumber', function() {
-    assert.strictEqual(getBlockList().length, 6);
+    assert.strictEqual(getBlockList().length, 11);
   });
 });
 
@@ -47,8 +47,6 @@ describe('renderWithUserConfig', function() {
     assert.match(render('string', '1234567890'), /1234567890/);
   });
   it('invalidUserConfig', function() {
-    const svg = render('operator', '1234567890');
-    assert.doesNotMatch(svg, /1234567890/);
-    assert.match(svg, /\+/);
+    assert.throws(() => render('operator', '1234567890'));
   });
 });


### PR DESCRIPTION
Now the utility supports prototyping simple statements such as break, continue, return..., eval..., set...to.... E.g.,

node . -b set -o out.svg -c 'y|3.14,×,x
![demo1](https://user-images.githubusercontent.com/5819968/122798858-a4e09680-d2f3-11eb-8950-10edf6175b65.png)

node . -b eval -o out.svg -c '(,x,+,y,),>=,z'
![demo2](https://user-images.githubusercontent.com/5819968/122798948-bfb30b00-d2f3-11eb-81df-5b069122903f.png)

And, a manually stacked simple statements:
![demo](https://user-images.githubusercontent.com/5819968/122799025-d78a8f00-d2f3-11eb-934b-7e256e91e8de.png)
