### PR TITLE
Add ast design and asdl file for SeedAST

### DIFF
--- a/design/ast.md
+++ b/design/ast.md
@@ -1,9 +1,10 @@
 # SeedAST
 
 The SeedAST (Seed Abstract Syntax Tree) is a high-level representation of the
-SeedBlock program structure. It can be thought of as an abstract representation
-of the source code. The specification of the AST nodes is specified using the
-[Zephyr Abstract Syntax Definition Language (ASDL)](https://www.usenix.org/legacy/publications/library/proceedings/dsl97/full_papers/wang/wang.pdf).
+SeedBlock and SeedX program structure. It can be thought of as an abstract
+representation of the source code. The specification of the AST nodes is
+specified using the [Zephyr Abstract Syntax Definition Language
+(ASDL)](https://www.usenix.org/legacy/publications/library/proceedings/dsl97/full_papers/wang/wang.pdf).
 
 The Zephyr Abstract Syntax Description Language (ASDL) is a simple declarative
 language designed to describe the tree-like data structures in compilers. Tools
@@ -11,4 +12,4 @@ can convert ASDL descriptions into the appropriate data structure definitions
 and functions in any target language.
 
 The definition of the AST nodes for SeedAST is found in the file
-`grammars/SeedAST.asdl`.
+[grammars/SeedAST.asdl](/grammars/SeedPython.g4).

--- a/design/ast.md
+++ b/design/ast.md
@@ -12,4 +12,4 @@ can convert ASDL descriptions into the appropriate data structure definitions
 and functions in any target language.
 
 The definition of the AST nodes for SeedAST is found in the file
-[grammars/SeedAST.asdl](/grammars/SeedPython.g4).
+[grammars/SeedAST.asdl](/grammars/SeedAST.asdl).

--- a/design/ast.md
+++ b/design/ast.md
@@ -1,0 +1,14 @@
+# SeedAST
+
+The SeedAST (Seed Abstract Syntax Tree) is a high-level representation of the
+SeedBlock program structure. It can be thought of as an abstract representation
+of the source code. The specification of the AST nodes is specified using the
+[Zephyr Abstract Syntax Definition Language (ASDL)](https://www.usenix.org/legacy/publications/library/proceedings/dsl97/full_papers/wang/wang.pdf).
+
+The Zephyr Abstract Syntax Description Language (ASDL) is a simple declarative
+language designed to describe the tree-like data structures in compilers. Tools
+can convert ASDL descriptions into the appropriate data structure definitions
+and functions in any target language.
+
+The definition of the AST nodes for SeedAST is found in the file
+`grammars/SeedAST.asdl`.

--- a/grammars/SeedAST.asdl
+++ b/grammars/SeedAST.asdl
@@ -1,3 +1,19 @@
+--
+-- Copyright 2021 The Aha001 Team.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
 -- ASDL's 4 builtin types are:
 -- identifier, int, string, constant
 

--- a/grammars/SeedAST.asdl
+++ b/grammars/SeedAST.asdl
@@ -1,0 +1,14 @@
+-- ASDL's 4 builtin types are:
+-- identifier, int, string, constant
+
+module SeedAST
+{
+    stmt = Assign(identifier variable, expr value)
+        | Eval(expr value)
+
+    expr = Binary(expr left, operator op, expr right)
+        | Variable(identifier name)
+        | Constant(constant value)
+
+    operator = Add | Sub | Mul | Div
+}


### PR DESCRIPTION
Suggest to use Zephyr Abstract Syntax Definition Language as the specification of SeedAST. The final C# code of SeedAST can be written by hand or generated from ASDL file by a tool.