### PR TITLE
Update .editorconfig based on Google C# style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -64,58 +64,26 @@ dotnet_style_explicit_tuple_names = true:suggestion
 # Whitespace options
 dotnet_style_allow_multiple_blank_lines_experimental = false
 
-# Non-private static fields are PascalCase
-dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
-dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+# Public fields and properties are PascalCase
+dotnet_naming_rule.public_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascal_case.symbols = public_fields
+dotnet_naming_rule.public_fields_should_be_pascal_case.style = public_field_style
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public
 
-dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
-dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
-dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+dotnet_naming_symbols.public_fields.applicable_kinds = field, property
 
-dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
+dotnet_naming_style.public_field_style.capitalization = pascal_case
 
-# Non-private readonly fields are PascalCase
-dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
-dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_readonly_field_style
+# Non-public fields and properties are camelCase and start with _
+dotnet_naming_rule.non_public_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.non_public_fields_should_be_camel_case.symbols = non_public_fields
+dotnet_naming_rule.non_public_fields_should_be_camel_case.style = non_public_field_style
+dotnet_naming_symbols.non_public_fields.applicable_accessibilities = private, protected, internal, protected_internal, private_protected
 
-dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
-dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
-dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
+dotnet_naming_symbols.non_public_fields.applicable_kinds = field, property
 
-dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
-
-# Constants are PascalCase
-dotnet_naming_rule.constants_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
-dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
-
-dotnet_naming_symbols.constants.applicable_kinds = field, local
-dotnet_naming_symbols.constants.required_modifiers = const
-
-dotnet_naming_style.constant_style.capitalization = pascal_case
-
-# Static fields are camelCase and start with s_
-dotnet_naming_rule.static_fields_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.static_fields_should_be_camel_case.symbols = static_fields
-dotnet_naming_rule.static_fields_should_be_camel_case.style = static_field_style
-
-dotnet_naming_symbols.static_fields.applicable_kinds = field
-dotnet_naming_symbols.static_fields.required_modifiers = static
-
-dotnet_naming_style.static_field_style.capitalization = camel_case
-dotnet_naming_style.static_field_style.required_prefix = s_
-
-# Instance fields are camelCase and start with _
-dotnet_naming_rule.instance_fields_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
-dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
-
-dotnet_naming_symbols.instance_fields.applicable_kinds = field
-
-dotnet_naming_style.instance_field_style.capitalization = camel_case
-dotnet_naming_style.instance_field_style.required_prefix = _
+dotnet_naming_style.non_public_field_style.capitalization = camel_case
+dotnet_naming_style.non_public_field_style.required_prefix = _
 
 # Locals and parameters are camelCase
 dotnet_naming_rule.locals_should_be_camel_case.severity = suggestion


### PR DESCRIPTION
See https://google.github.io/styleguide/csharp-style.html

- Names of classes, methods, enumerations, public fields, public properties, namespaces: PascalCase.
- Names of local variables, parameters: camelCase.
- Names of private, protected, internal and protected internal fields and properties: _camelCase.
- Naming convention is unaffected by modifiers such as const, static, readonly, etc.