### PR TITLE
Implement block parser

### DIFF
--- a/csharp/src/SeedLang.Ast/Expressions.cs
+++ b/csharp/src/SeedLang.Ast/Expressions.cs
@@ -12,27 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using SeedLang.Runtime;
 
 namespace SeedLang.Ast {
   // The base class of all expression nodes.
   public abstract class Expression : AstNode {
-    // The factory method to create the binary expression.
+    // The factory method to create a binary expression.
     public static BinaryExpression Binary(Expression left, BinaryOperator op, Expression right) {
       return new BinaryExpression(left, op, right);
     }
 
-    // The factory method to create the identifier expression.
+    // The factory method to create an identifier expression.
     public static IdentifierExpression Identifier(string name) {
       return new IdentifierExpression(name);
     }
 
-    // The factory method to create the number constant expression.
+    // The factory method to create a number constant expression from a string.
+    public static NumberConstantExpression Number(string valueStr) {
+      try {
+        return Number(double.Parse(valueStr));
+      } catch (Exception) {
+        return Number(0);
+      }
+    }
+
+    // The factory method to create a number constant expression.
     public static NumberConstantExpression Number(double value) {
       return new NumberConstantExpression(value);
     }
 
-    // The factory method to create the string constant expression.
+    // The factory method to create a string constant expression.
     public static StringConstantExpression String(string value) {
       return new StringConstantExpression(value);
     }

--- a/csharp/src/SeedLang.Block/Parser.cs
+++ b/csharp/src/SeedLang.Block/Parser.cs
@@ -1,0 +1,61 @@
+// Copyright 2021 The Aha001 Team.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using SeedLang.X;
+
+namespace SeedLang.Block {
+  // A parser class which is responsible to convert a block program to an AST tree, an inline
+  // expression text to a list of blocks, and an inline expression text to an AST tree.
+  public class Parser {
+    private class ExressionListener : BlockParser.IExpressionListener {
+      public readonly List<BaseBlock> Blocks = new List<BaseBlock>();
+
+      public void VisitArithmeticOperator(string op) {
+        Blocks.Add(new ArithmeticOperatorBlock { Name = op });
+      }
+
+      public void VisitCloseParen() {
+        Blocks.Add(new ParenthesisBlock(ParenthesisBlock.Type.Right));
+      }
+
+      public void VisitIdentifier(string name) {
+        throw new System.NotImplementedException();
+      }
+
+      public void VisitNumber(string number) {
+        Blocks.Add(new NumberBlock { Value = number });
+      }
+
+      public void VisitOpenParen() {
+        Blocks.Add(new ParenthesisBlock(ParenthesisBlock.Type.Left));
+      }
+
+      public void VisitString(string str) {
+        throw new System.NotImplementedException();
+      }
+    }
+
+    // Converts an expression text to a list of blocks.
+    public static IEnumerable<BaseBlock> ExpressionTextToBlocks(string text) {
+      var blockParser = new BlockParser();
+      var listener = new ExressionListener();
+      blockParser.VisitExpression(text, listener);
+      return listener.Blocks;
+    }
+
+    // TODO: implement parsing a block program to an AST tree, and an inline expression text to an
+    // AST tree.
+  }
+}

--- a/csharp/src/SeedLang.Block/Parser.cs
+++ b/csharp/src/SeedLang.Block/Parser.cs
@@ -16,8 +16,12 @@ using System.Collections.Generic;
 using SeedLang.X;
 
 namespace SeedLang.Block {
-  // A parser class which is responsible to convert a block program to an AST tree, an inline
-  // expression text to a list of blocks, and an inline expression text to an AST tree.
+  // The parser that converts a block program to an AST tree, an inline expression text to a list of
+  // blocks, or an inline expression text to an AST tree.
+  //
+  // This class is different from SeedLang.X.BlockParser, which is only responsible for parsing text
+  // source code of block programs. This class invokes the interfaces of SeedLang.X.BlockParser to
+  // convert from an inline expression text to a list of blocks or an AST tree.
   public class Parser {
     private class ExressionListener : BlockParser.IExpressionListener {
       public readonly List<BaseBlock> Blocks = new List<BaseBlock>();

--- a/csharp/src/SeedLang.Block/SeedLang.Block.csproj
+++ b/csharp/src/SeedLang.Block/SeedLang.Block.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SeedLang.Common\SeedLang.Common.csproj" />
+    <ProjectReference Include="..\SeedLang.X\SeedLang.X.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/csharp/src/SeedLang.X/BaseParser.cs
+++ b/csharp/src/SeedLang.X/BaseParser.cs
@@ -1,0 +1,115 @@
+// Copyright 2021 The Aha001 Team.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Tree;
+using SeedLang.Ast;
+using SeedLang.Common;
+
+namespace SeedLang.X {
+  // The abstract base class of the block parser and all SeedX language parsers.
+  //
+  // It provides interfaces to validate the SeedPython source code, and parse it into an AST tree
+  // based on the predefined rules.
+  public abstract class BaseParser {
+    // Validates source code based on the parse rule. The concrete ANTLR4 lexer and parser are
+    // created by the derived class.
+    public bool Validate(string source, string module, ParseRule rule,
+                         DiagnosticCollection collection) {
+      if (string.IsNullOrEmpty(source) || module is null) {
+        return false;
+      }
+      var localCollection = collection ?? new DiagnosticCollection();
+      int diagnosticCount = localCollection.Diagnostics.Count;
+      Parser parser = SetupParser(source, module, localCollection);
+      GetContext(parser, rule);
+      return localCollection.Diagnostics.Count == diagnosticCount;
+    }
+
+    // Parses source code into an AST tree based on the parse rule. The concrete ANTLR4 lexer and
+    // parser are created by the derived class. The out node is set to null if the given source code
+    // is not valid.
+    public bool TryParse(string source, string module, ParseRule rule,
+                         DiagnosticCollection collection, out AstNode node) {
+      if (string.IsNullOrEmpty(source) || module is null) {
+        node = null;
+        return false;
+      }
+      DiagnosticCollection localCollection = collection ?? new DiagnosticCollection();
+      int diagnosticCount = localCollection.Diagnostics.Count;
+      Parser parser = SetupParser(source, module, localCollection);
+      ParserRuleContext context = GetContext(parser, rule);
+      var visitor = MakeVisitor();
+      node = visitor.Visit(context);
+      if (localCollection.Diagnostics.Count > diagnosticCount) {
+        node = null;
+      }
+      return localCollection.Diagnostics.Count == diagnosticCount;
+    }
+
+    protected abstract Lexer MakeLexer(ICharStream stream);
+
+    protected abstract Parser MakeParser(ITokenStream stream);
+
+    protected abstract AbstractParseTreeVisitor<AstNode> MakeVisitor();
+
+    protected abstract ParserRuleContext SingleIdentifier(Parser parser);
+
+    protected abstract ParserRuleContext SingleNumber(Parser parser);
+
+    protected abstract ParserRuleContext SingleString(Parser parser);
+
+    protected abstract ParserRuleContext SingleExpr(Parser parser);
+
+    protected abstract ParserRuleContext SingleStmt(Parser parser);
+
+    protected Lexer SetupLexer(string source) {
+      var inputStream = new AntlrInputStream(source);
+      var lexer = MakeLexer(inputStream);
+      lexer.RemoveErrorListeners();
+      return lexer;
+    }
+
+    protected Parser SetupParser(string source, string module, DiagnosticCollection collection) {
+      var lexer = SetupLexer(source);
+      var tokenStream = new CommonTokenStream(lexer);
+      Parser parser = MakeParser(tokenStream);
+      // Removes default error listerners which include a console error reporter.
+      parser.RemoveErrorListeners();
+      if (!(collection is null)) {
+        parser.ErrorHandler = new SyntaxErrorStrategy(module, collection);
+      }
+      return parser;
+    }
+
+    protected ParserRuleContext GetContext(Parser parser, ParseRule rule) {
+      switch (rule) {
+        case ParseRule.Identifier:
+          return SingleIdentifier(parser);
+        case ParseRule.Number:
+          return SingleNumber(parser);
+        case ParseRule.String:
+          return SingleString(parser);
+        case ParseRule.Expression:
+          return SingleExpr(parser);
+        case ParseRule.Statement:
+          return SingleStmt(parser);
+        default:
+          Debug.Assert(false, $"Not implemented parse rule: {rule}");
+          return null;
+      }
+    }
+  }
+}

--- a/csharp/src/SeedLang.X/BaseParser.cs
+++ b/csharp/src/SeedLang.X/BaseParser.cs
@@ -21,8 +21,8 @@ using SeedLang.Common;
 namespace SeedLang.X {
   // The abstract base class of the block parser and all SeedX language parsers.
   //
-  // It provides interfaces to validate the SeedPython source code, and parse it into an AST tree
-  // based on the predefined rules.
+  // It provides interfaces to validate the text source code, and parse it into an AST tree based on
+  // the predefined rules.
   public abstract class BaseParser {
     // Validates source code based on the parse rule. The concrete ANTLR4 lexer and parser are
     // created by the derived class.

--- a/csharp/src/SeedLang.X/BlockParser.cs
+++ b/csharp/src/SeedLang.X/BlockParser.cs
@@ -1,0 +1,121 @@
+// Copyright 2021 The Aha001 Team.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Tree;
+using SeedLang.Ast;
+using SeedLang.Common;
+
+namespace SeedLang.X {
+  // The text parser of SeedBlock language.
+  //
+  // The BlockParser inherits the interfaces of BaseParser and provides additional interface to
+  // visit expression source code of block programs.
+  public class BlockParser : BaseParser {
+    // The listener interface to be notified when the tokens of expression source code are visited.
+    public interface IExpressionListener {
+      void VisitArithmeticOperator(string op);
+      void VisitIdentifier(string name);
+      void VisitNumber(string number);
+      void VisitString(string str);
+      void VisitOpenParen();
+      void VisitCloseParen();
+    }
+
+    // Visits expression source code of block programs. The given listener is notified when each
+    // token of the expression is visited. The negative sign token will be combined with the
+    // following number to form a negative number.
+    public void VisitExpression(string source, IExpressionListener listener) {
+      if (!Validate(source, "", ParseRule.Expression, null)) {
+        return;
+      }
+      Lexer lexer = SetupLexer(source);
+      int lastTokenType = SeedBlockParser.UNKNOWN_CHAR;
+      bool negative = false;
+      foreach (var token in lexer.GetAllTokens()) {
+        switch (token.Type) {
+          case SeedBlockLexer.ADD:
+          case SeedBlockLexer.MUL:
+          case SeedBlockLexer.DIV:
+            listener.VisitArithmeticOperator(token.Text);
+            break;
+          case SeedBlockLexer.SUB:
+            if (lastTokenType != SeedBlockParser.NUMBER) {
+              negative = true;
+            } else {
+              listener.VisitArithmeticOperator(token.Text);
+            }
+            break;
+          case SeedBlockLexer.IDENTIFIER:
+            listener.VisitIdentifier(token.Text);
+            break;
+          case SeedBlockLexer.NUMBER:
+            listener.VisitNumber((negative ? "-" : "") + token.Text);
+            negative = false;
+            break;
+          case SeedBlockLexer.STRING:
+            listener.VisitString(token.Text);
+            break;
+          case SeedBlockLexer.OPEN_PAREN:
+            listener.VisitOpenParen();
+            break;
+          case SeedBlockLexer.CLOSE_PAREN:
+            listener.VisitCloseParen();
+            break;
+          default:
+            break;
+        }
+        lastTokenType = token.Type;
+      }
+    }
+
+    protected override Lexer MakeLexer(ICharStream stream) {
+      return new SeedBlockLexer(stream);
+    }
+
+    protected override Parser MakeParser(ITokenStream stream) {
+      return new SeedBlockParser(stream);
+    }
+
+    protected override AbstractParseTreeVisitor<AstNode> MakeVisitor() {
+      return new BlockVisitor();
+    }
+
+    protected override ParserRuleContext SingleExpr(Parser parser) {
+      Debug.Assert(parser is SeedBlockParser, $"Incorrect parser type: {parser}");
+      return (parser as SeedBlockParser).single_expr();
+    }
+
+    protected override ParserRuleContext SingleIdentifier(Parser parser) {
+      Debug.Assert(parser is SeedBlockParser, $"Incorrect parser type: {parser}");
+      return (parser as SeedBlockParser).single_identifier();
+    }
+
+    protected override ParserRuleContext SingleNumber(Parser parser) {
+      Debug.Assert(parser is SeedBlockParser, $"Incorrect parser type: {parser}");
+      return (parser as SeedBlockParser).single_number();
+    }
+
+    protected override ParserRuleContext SingleStmt(Parser parser) {
+      Debug.Assert(parser is SeedBlockParser, $"Incorrect parser type: {parser}");
+      return (parser as SeedBlockParser).single_stmt();
+    }
+
+    protected override ParserRuleContext SingleString(Parser parser) {
+      Debug.Assert(parser is SeedBlockParser, $"Incorrect parser type: {parser}");
+      return (parser as SeedBlockParser).single_string();
+    }
+  }
+}

--- a/csharp/src/SeedLang.X/BlockParser.cs
+++ b/csharp/src/SeedLang.X/BlockParser.cs
@@ -21,7 +21,7 @@ using SeedLang.Common;
 namespace SeedLang.X {
   // The text parser of SeedBlock language.
   //
-  // The BlockParser inherits the interfaces of BaseParser and provides additional interface to
+  // The BlockParser inherits the interfaces of BaseParser and provides an additional interface to
   // visit expression source code of block programs.
   public class BlockParser : BaseParser {
     // The listener interface to be notified when the tokens of expression source code are visited.

--- a/csharp/src/SeedLang.X/PythonParser.cs
+++ b/csharp/src/SeedLang.X/PythonParser.cs
@@ -14,95 +14,49 @@
 
 using System.Diagnostics;
 using Antlr4.Runtime;
+using Antlr4.Runtime.Tree;
 using SeedLang.Ast;
-using SeedLang.Common;
 
 namespace SeedLang.X {
   // The parser of SeedPython language.
   //
-  // The PythonParser provides interfaces to validate the SeedPython source code, and parse it into
-  // the AST tree based on the predefined rules.
-  public sealed class PythonParser {
-    // Validate SeedPython source code based on the parse rule.
-    public static bool Validate(string source, string module, ParseRule rule,
-                                DiagnosticCollection collection) {
-      if (string.IsNullOrEmpty(source) || module is null) {
-        return false;
-      }
-      var localCollection = collection ?? new DiagnosticCollection();
-      int diagnosticCount = localCollection.Diagnostics.Count;
-      SeedPythonParser parser = SetupParser(source, module, localCollection);
-      switch (rule) {
-        case ParseRule.Identifier:
-          parser.single_identifier();
-          break;
-        case ParseRule.Number:
-          parser.single_number();
-          break;
-        case ParseRule.String:
-          parser.single_string();
-          break;
-        case ParseRule.Expression:
-          parser.single_expr();
-          break;
-        case ParseRule.Statement:
-          parser.single_stmt();
-          break;
-        default:
-          Debug.Assert(false, $"Not implemented parse rule: {rule}");
-          break;
-      }
-      return localCollection.Diagnostics.Count == diagnosticCount;
+  // The BlockParser inherits the interfaces of BaseParser.
+  public class PythonParser : BaseParser {
+    protected override Lexer MakeLexer(ICharStream stream) {
+      return new SeedPythonLexer(stream);
     }
 
-    // Parses SeedPython source code into the AST tree based on the parse rule. Returns null if
-    // any parsing error happens.
-    public static AstNode Parse(string source, string module, ParseRule rule,
-                                DiagnosticCollection collection) {
-      if (string.IsNullOrEmpty(source) || module is null) {
-        return null;
-      }
-      DiagnosticCollection localCollection = collection ?? new DiagnosticCollection();
-      int diagnosticCount = localCollection.Diagnostics.Count;
-      SeedPythonParser parser = SetupParser(source, module, localCollection);
-      var visitor = new PythonVisitor();
-      AstNode node = null;
-      switch (rule) {
-        case ParseRule.Identifier:
-          node = visitor.Visit(parser.single_identifier());
-          break;
-        case ParseRule.Number:
-          node = visitor.Visit(parser.single_number());
-          break;
-        case ParseRule.String:
-          node = visitor.Visit(parser.single_string());
-          break;
-        case ParseRule.Expression:
-          node = visitor.Visit(parser.single_expr());
-          break;
-        case ParseRule.Statement:
-          node = visitor.Visit(parser.single_stmt());
-          break;
-        default:
-          Debug.Assert(false, $"Unsupported parse rule: {rule}");
-          break;
-      }
-      return localCollection.Diagnostics.Count > diagnosticCount ? null : node;
+    protected override Parser MakeParser(ITokenStream stream) {
+      return new SeedPythonParser(stream);
     }
 
-    private static SeedPythonParser SetupParser(string source, string module,
-                                                DiagnosticCollection collection) {
-      var inputStream = new AntlrInputStream(source);
-      var lexer = new SeedPythonLexer(inputStream);
-      var tokenStream = new CommonTokenStream(lexer);
-      var parser = new SeedPythonParser(tokenStream);
-      // Removes default error listerners which include a console error reporter.
-      lexer.RemoveErrorListeners();
-      parser.RemoveErrorListeners();
-      if (!(collection is null)) {
-        parser.ErrorHandler = new SyntaxErrorStrategy(module, collection);
-      }
-      return parser;
+    protected override AbstractParseTreeVisitor<AstNode> MakeVisitor() {
+      return new PythonVisitor();
+    }
+
+    protected override ParserRuleContext SingleExpr(Parser parser) {
+      Debug.Assert(parser is SeedPythonParser, $"Incorrect parser type: {parser}");
+      return (parser as SeedPythonParser).single_expr();
+    }
+
+    protected override ParserRuleContext SingleIdentifier(Parser parser) {
+      Debug.Assert(parser is SeedPythonParser, $"Incorrect parser type: {parser}");
+      return (parser as SeedPythonParser).single_identifier();
+    }
+
+    protected override ParserRuleContext SingleNumber(Parser parser) {
+      Debug.Assert(parser is SeedPythonParser, $"Incorrect parser type: {parser}");
+      return (parser as SeedPythonParser).single_number();
+    }
+
+    protected override ParserRuleContext SingleStmt(Parser parser) {
+      Debug.Assert(parser is SeedPythonParser, $"Incorrect parser type: {parser}");
+      return (parser as SeedPythonParser).single_stmt();
+    }
+
+    protected override ParserRuleContext SingleString(Parser parser) {
+      Debug.Assert(parser is SeedPythonParser, $"Incorrect parser type: {parser}");
+      return (parser as SeedPythonParser).single_string();
     }
   }
 }

--- a/csharp/src/SeedLang/Engine.cs
+++ b/csharp/src/SeedLang/Engine.cs
@@ -49,30 +49,27 @@ namespace SeedLang {
 
     public bool Run(string source, string module, ProgrammingLanguage language, ParseRule rule,
                     RunType runType, DiagnosticCollection collection = null) {
+      BaseParser parser = MakeParser(language);
       if (runType == RunType.DryRun) {
-        switch (language) {
-          case ProgrammingLanguage.Python:
-            return PythonParser.Validate(source, module, rule, collection);
-          default:
-            Debug.Assert(false, $"Not implemented SeedX language: {language}");
-            return false;
-        }
+        return parser.Validate(source, module, rule, collection);
       }
-
-      AstNode node = null;
-      switch (language) {
-        case ProgrammingLanguage.Python:
-          node = PythonParser.Parse(source, module, rule, collection);
-          break;
-        default:
-          Debug.Assert(false, $"Not implemented SeedX language: {language}");
-          break;
-      }
-      if (!(node is null)) {
+      if (parser.TryParse(source, module, rule, collection, out AstNode node)) {
         _executor.Run(node);
         return true;
       }
       return false;
+    }
+
+    private static BaseParser MakeParser(ProgrammingLanguage language) {
+      switch (language) {
+        case ProgrammingLanguage.Block:
+          return new BlockParser();
+        case ProgrammingLanguage.Python:
+          return new PythonParser();
+        default:
+          Debug.Assert(false, $"Not implemented SeedX language: {language}");
+          return null;
+      }
     }
   }
 }

--- a/csharp/tests/SeedLang.Block.Tests/ParserTest.cs
+++ b/csharp/tests/SeedLang.Block.Tests/ParserTest.cs
@@ -1,0 +1,34 @@
+// Copyright 2021 The Aha001 Team.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace SeedLang.Block.Tests {
+  public class ParserTests {
+    [Fact]
+    public void TestExpressionTextToBlocks() {
+      var module = new Module { Name = "Main" };
+      var expressionBlock = new ExpressionBlock();
+      module.AddStandaloneBlock(expressionBlock);
+      var blocks = Parser.ExpressionTextToBlocks("(1 + 2) * 3 / -4 + 3.14");
+      int index = 0;
+      foreach (var block in blocks) {
+        module.AddStandaloneBlock(block);
+        expressionBlock.Dock(block, Position.DockType.Input, index++);
+      }
+      Assert.Equal(11, index);
+      Assert.Equal("(1+2)*3/-4+3.14", expressionBlock.GetEditableText());
+    }
+  }
+}

--- a/csharp/tests/SeedLang.X.Tests/BlockParserTests.cs
+++ b/csharp/tests/SeedLang.X.Tests/BlockParserTests.cs
@@ -1,0 +1,114 @@
+// Copyright 2021 The Aha001 Team.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using SeedLang.Ast;
+using SeedLang.Common;
+using Xunit;
+
+namespace SeedLang.X.Tests {
+  public class BlockParserTests {
+    private class MockupExpressionListener : BlockParser.IExpressionListener {
+      private readonly List<string> _texts = new List<string>();
+
+      public override string ToString() {
+        return string.Join(',', _texts);
+      }
+
+      public void VisitArithmeticOperator(string op) {
+        _texts.Add(op);
+      }
+
+      public void VisitCloseParen() {
+        _texts.Add(")");
+      }
+
+      public void VisitIdentifier(string name) {
+        _texts.Add(name);
+      }
+
+      public void VisitNumber(string number) {
+        _texts.Add(number);
+      }
+
+      public void VisitOpenParen() {
+        _texts.Add("(");
+      }
+
+      public void VisitString(string str) {
+        _texts.Add(str);
+      }
+    }
+
+    [Theory]
+    [InlineData("0", true)]
+    [InlineData("0.", true)]
+    [InlineData(".0", true)]
+    [InlineData(".5", true)]
+    [InlineData("1.5", true)]
+    [InlineData("1e3", true)]
+    [InlineData("1e+20", true)]
+    [InlineData("1e-5", true)]
+    [InlineData("..1", false)]
+    [InlineData("1.2.3", false)]
+    [InlineData("1a", false)]
+    public void TestValidateNumber(string input, bool result) {
+      var collection = new DiagnosticCollection();
+      var parser = new BlockParser();
+      Assert.Equal(result, parser.Validate(input, "", ParseRule.Number, collection));
+    }
+
+    [Theory]
+    [InlineData("0", "0")]
+    [InlineData("0.", "0")]
+    [InlineData(".0", "0")]
+    [InlineData(".5", "0.5")]
+    [InlineData("1.5", "1.5")]
+    [InlineData("1e3", "1000")]
+    [InlineData("1e+20", "1E+20")]
+    [InlineData("1e-5", "1E-05")]
+    public void TestParseNumber(string input, string expected) {
+      var collection = new DiagnosticCollection();
+      var parser = new BlockParser();
+      Assert.True(parser.TryParse(input, "", ParseRule.Number, collection, out AstNode node));
+      Assert.NotNull(node);
+      Assert.Empty(collection.Diagnostics);
+      Assert.Equal(expected, node.ToString());
+    }
+
+    [Theory]
+    [InlineData("1 + 2", "(1 + 2)")]
+    [InlineData("1 - 2 * 3", "(1 - (2 * 3))")]
+    [InlineData("(1 + 2) / 3", "((1 + 2) / 3)")]
+    public void TestParseBinaryExpression(string input, string expected) {
+      var collection = new DiagnosticCollection();
+      var parser = new BlockParser();
+      Assert.True(parser.TryParse(input, "", ParseRule.Expression, collection, out AstNode node));
+      Assert.NotNull(node);
+      Assert.Empty(collection.Diagnostics);
+      Assert.Equal(expected, node.ToString());
+    }
+
+    [Theory]
+    [InlineData("1.5 + 210 - 3 * 4 / 5", "1.5,+,210,-,3,*,4,/,5")]
+    [InlineData("(1 + 2) / 3", "(,1,+,2,),/,3")]
+    [InlineData("(1 + 2) / -3", "(,1,+,2,),/,-3")]
+    public void TestVisitExpression(string input, string expected) {
+      var parser = new BlockParser();
+      var listener = new MockupExpressionListener();
+      parser.VisitExpression(input, listener);
+      Assert.Equal(expected, listener.ToString());
+    }
+  }
+}

--- a/csharp/tests/SeedLang.X.Tests/PythonParserTests.cs
+++ b/csharp/tests/SeedLang.X.Tests/PythonParserTests.cs
@@ -32,7 +32,8 @@ namespace SeedLang.X.Tests {
     [InlineData("1a", false)]
     public void TestValidateNumber(string input, bool result) {
       var collection = new DiagnosticCollection();
-      Assert.Equal(result, PythonParser.Validate(input, "", ParseRule.Number, collection));
+      var parser = new PythonParser();
+      Assert.Equal(result, parser.Validate(input, "", ParseRule.Number, collection));
     }
 
     [Theory]
@@ -46,7 +47,8 @@ namespace SeedLang.X.Tests {
     [InlineData("1e-5", "1E-05")]
     public void TestParseNumber(string input, string expected) {
       var collection = new DiagnosticCollection();
-      AstNode node = PythonParser.Parse(input, "", ParseRule.Number, collection);
+      var parser = new PythonParser();
+      Assert.True(parser.TryParse(input, "", ParseRule.Number, collection, out AstNode node));
       Assert.NotNull(node);
       Assert.Empty(collection.Diagnostics);
       Assert.Equal(expected, node.ToString());
@@ -58,7 +60,8 @@ namespace SeedLang.X.Tests {
     [InlineData("(1 + 2) / 3", "((1 + 2) / 3)")]
     public void TestParseBinaryExpression(string input, string expected) {
       var collection = new DiagnosticCollection();
-      AstNode node = PythonParser.Parse(input, "", ParseRule.Expression, collection);
+      var parser = new PythonParser();
+      Assert.True(parser.TryParse(input, "", ParseRule.Expression, collection, out AstNode node));
       Assert.NotNull(node);
       Assert.Empty(collection.Diagnostics);
       Assert.Equal(expected, node.ToString());
@@ -69,14 +72,16 @@ namespace SeedLang.X.Tests {
     [InlineData("eval 1 +", false)]
     public void TestValidateEvalStatement(string input, bool result) {
       var collection = new DiagnosticCollection();
-      Assert.Equal(result, PythonParser.Validate(input, "", ParseRule.Statement, collection));
+      var parser = new PythonParser();
+      Assert.Equal(result, parser.Validate(input, "", ParseRule.Statement, collection));
     }
 
     [Theory]
     [InlineData("id = 1", "id = 1\n")]
     public void TestParseAssignmentStatement(string input, string expected) {
       var collection = new DiagnosticCollection();
-      AstNode node = PythonParser.Parse(input, "", ParseRule.Statement, collection);
+      var parser = new PythonParser();
+      Assert.True(parser.TryParse(input, "", ParseRule.Statement, collection, out AstNode node));
       Assert.NotNull(node);
       Assert.Empty(collection.Diagnostics);
       Assert.Equal(expected, node.ToString());
@@ -86,7 +91,8 @@ namespace SeedLang.X.Tests {
     [InlineData("eval 1 + 2 * 3 - 4", "eval ((1 + (2 * 3)) - 4)\n")]
     public void TestParseEvalStatement(string input, string expected) {
       var collection = new DiagnosticCollection();
-      AstNode node = PythonParser.Parse(input, "", ParseRule.Statement, collection);
+      var parser = new PythonParser();
+      Assert.True(parser.TryParse(input, "", ParseRule.Statement, collection, out AstNode node));
       Assert.NotNull(node);
       Assert.Empty(collection.Diagnostics);
       Assert.Equal(expected, node.ToString());
@@ -99,7 +105,8 @@ namespace SeedLang.X.Tests {
     [InlineData("eval 1.2 =", @"SyntaxErrorUnwantedToken '=' <EOF>")]
     public void TestParseSingleSyntaxError(string input, string localizedMessage) {
       var collection = new DiagnosticCollection();
-      AstNode node = PythonParser.Parse(input, "", ParseRule.Statement, collection);
+      var parser = new PythonParser();
+      Assert.False(parser.TryParse(input, "", ParseRule.Statement, collection, out AstNode node));
       Assert.Null(node);
       Assert.Single(collection.Diagnostics);
       Assert.Equal(SystemReporters.SeedX, collection.Diagnostics[0].Reporter);

--- a/grammars/Common.g4
+++ b/grammars/Common.g4
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2021 The Aha001 Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+grammar Common;
+
+@header {
+  #pragma warning disable 3021
+}
+
+/*
+ * Parser rules
+ */
+
+single_identifier: IDENTIFIER EOF;
+single_number: NUMBER EOF;
+single_string: STRING EOF;
+single_expr: expr EOF;
+
+expr:
+  expr op = (MUL | DIV) expr   # mul_div
+  | expr op = (ADD | SUB) expr # add_sub
+  | SUB expr                   # unary
+  | IDENTIFIER                 # identifier
+  | NUMBER                     # number
+  | '(' expr ')'               # grouping;
+
+/*
+ * Lexer rules
+ */
+
+ADD: '+';
+SUB: '-';
+MUL: '*';
+DIV: '/';
+
+IDENTIFIER: ID_START ID_CONTINUE*;
+
+NUMBER: INTEGER | FLOAT_NUMBER;
+
+STRING: '"' .*? '"';
+
+INTEGER: DECIMAL_INTEGER;
+
+DECIMAL_INTEGER: NON_ZERO_DIGIT DIGIT* | '0'+;
+
+FLOAT_NUMBER: POINT_FLOAT | EXPONENT_FLOAT;
+
+OPEN_PAREN: '(';
+CLOSE_PAREN: ')';
+OPEN_BRACK: '[';
+CLOSE_BRACK: ']';
+OPEN_BRACE: '{';
+CLOSE_BRACE: '}';
+
+NEWLINE: ( '\r'? '\n' | '\r' | '\f') SPACES?;
+
+SKIP_: ( SPACES | COMMENT | LINE_JOINING) -> skip;
+
+UNKNOWN_CHAR: .;
+
+/*
+ * Fragments
+ */
+
+fragment POINT_FLOAT:
+  INT_PART? FRACTION
+  | INT_PART '.';
+
+fragment EXPONENT_FLOAT: (INT_PART | POINT_FLOAT) EXPONENT;
+
+fragment INT_PART: DIGIT+;
+
+fragment FRACTION: '.' DIGIT+;
+
+fragment EXPONENT: [eE] [+-]? DIGIT+;
+
+fragment NON_ZERO_DIGIT: [1-9];
+
+fragment DIGIT: [0-9];
+
+fragment SPACES: [ \t]+;
+
+fragment COMMENT: '#' ~[\r\n\f]*;
+
+fragment LINE_JOINING:
+  '\\' SPACES? ('\r'? '\n' | '\r' | '\f');
+
+fragment ID_START: '_' | [A-Z] | [a-z];
+
+fragment ID_CONTINUE: ID_START | [0-9];

--- a/grammars/SeedBlock.g4
+++ b/grammars/SeedBlock.g4
@@ -16,9 +16,9 @@
 
 grammar SeedBlock;
 
-/*
- * Parser rules
- */
+import Common;
+
+single_stmt: stmt EOF;
 
 prog: stmt+;
 
@@ -26,34 +26,3 @@ stmt: assign_stmt | eval_stmt;
 
 assign_stmt: 'set' IDENTIFIER 'to' expr;
 eval_stmt: 'eval' expr;
-
-expr:
-    expr op = (MUL | DIV) expr   # mul_div
-    | expr op = (ADD | SUB) expr # add_sub
-    | IDENTIFIER                 # identifier
-    | NUMBER                     # number
-    | '(' expr ')'               # grouping;
-
-/*
- * Lexer rules
- */
-
-ADD: '+';
-SUB: '-';
-MUL: '*';
-DIV: '/';
-
-IDENTIFIER: ID_START ID_CONTINUE*;
-NUMBER: NON_ZERO_DIGIT DIGIT* | '0'+;
-
-WHITESPACE: [ \t\r\n] -> skip;
-
-/*
- * Fragments
- */
-
-fragment NON_ZERO_DIGIT: [1-9];
-fragment DIGIT: [0-9];
-fragment SPACES: [ \t]+;
-fragment ID_START: '_' | [A-Z] | [a-z];
-fragment ID_CONTINUE: ID_START | [0-9];

--- a/grammars/SeedPython.g4
+++ b/grammars/SeedPython.g4
@@ -48,23 +48,13 @@
 
 grammar SeedPython;
 
-@header {
-  #pragma warning disable 3021
-}
+import Common;
 
 tokens {
   INDENT,
   DEDENT
 }
 
-/*
- * Parser rules
- */
-
-single_identifier: identifier EOF;
-single_number: number EOF;
-single_string: string EOF;
-single_expr: expr EOF;
 single_stmt: small_stmt EOF;
 
 file_input: (NEWLINE | stmt)* EOF;
@@ -73,12 +63,9 @@ stmt: simple_stmt | compound_stmt;
 
 simple_stmt: small_stmt (';' small_stmt)* (';')?;
 
-small_stmt:
-  assignment_stmt
-  | eval_stmt
-  | flow_stmt;
+small_stmt: assign_stmt | eval_stmt | flow_stmt;
 
-assignment_stmt: identifier '=' expr;
+assign_stmt: IDENTIFIER '=' expr;
 eval_stmt: 'eval' expr;
 flow_stmt: break_stmt | continue_stmt;
 break_stmt: 'break';
@@ -96,79 +83,3 @@ suite: simple_stmt | NEWLINE INDENT stmt+ DEDENT;
 test: expr (comp_op expr)*;
 
 comp_op: '<' | '>' | '==' | '>=' | '<=' | '!=';
-
-expr:
-  expr op = (MUL | DIV) expr   # mul_div
-  | expr op = (ADD | SUB) expr # add_sub
-  | identifier                 # id
-  | number                     # num
-  | '(' expr ')'               # grouping;
-
-identifier: IDENTIFIER;
-
-number: INTEGER | FLOAT_NUMBER;
-
-string: STRING_LITERAL;
-
-/*
- * Lexer rules
- */
-
-ADD: '+';
-SUB: '-';
-MUL: '*';
-DIV: '/';
-
-IDENTIFIER: ID_START ID_CONTINUE*;
-
-INTEGER: DECIMAL_INTEGER;
-
-DECIMAL_INTEGER: NON_ZERO_DIGIT DIGIT* | '0'+;
-
-FLOAT_NUMBER: POINT_FLOAT | EXPONENT_FLOAT;
-
-STRING_LITERAL: '"' .*? '"';
-
-OPEN_PAREN: '(';
-CLOSE_PAREN: ')';
-OPEN_BRACK: '[';
-CLOSE_BRACK: ']';
-OPEN_BRACE: '{';
-CLOSE_BRACE: '}';
-
-NEWLINE: ( '\r'? '\n' | '\r' | '\f') SPACES?;
-
-SKIP_: ( SPACES | COMMENT | LINE_JOINING) -> skip;
-
-UNKNOWN_CHAR: .;
-
-/*
- * Fragments
- */
-
-fragment POINT_FLOAT:
-  INT_PART? FRACTION
-  | INT_PART '.';
-
-fragment EXPONENT_FLOAT: (INT_PART | POINT_FLOAT) EXPONENT;
-
-fragment INT_PART: DIGIT+;
-
-fragment FRACTION: '.' DIGIT+;
-
-fragment EXPONENT: [eE] [+-]? DIGIT+;
-
-fragment NON_ZERO_DIGIT: [1-9];
-
-fragment DIGIT: [0-9];
-
-fragment SPACES: [ \t]+;
-
-fragment COMMENT: '#' ~[\r\n\f]*;
-
-fragment LINE_JOINING:
-  '\\' SPACES? ('\r'? '\n' | '\r' | '\f');
-
-fragment ID_START: '_' | [A-Z] | [a-z];
-
-fragment ID_CONTINUE: ID_START | [0-9];

--- a/grammars/generate_parser.bat
+++ b/grammars/generate_parser.bat
@@ -29,4 +29,5 @@ set ANTLR4=java -jar "%ANTLR4_JAR_DIR%\%ANTLR4_JAR%"
 set SEEDX_DIR=..\csharp\src\SeedLang.X\antlr
 set FLAGS=-Dlanguage=CSharp -no-listener -visitor
 
+%ANTLR4% %FLAGS% -o "%SEEDX_DIR%" SeedBlock.g4
 %ANTLR4% %FLAGS% -o "%SEEDX_DIR%" SeedPython.g4

--- a/grammars/generate_parser.sh
+++ b/grammars/generate_parser.sh
@@ -29,4 +29,5 @@ readonly ANTLR4="java -jar ${ANTLR4_JAR_DIR}/${ANTLR4_JAR}"
 readonly SEEDX_DIR="../csharp/src/SeedLang.X/antlr"
 readonly FLAGS=(-Dlanguage=CSharp -no-listener -visitor)
 
+${ANTLR4} "${FLAGS[@]}" -o "${SEEDX_DIR}" SeedBlock.g4
 ${ANTLR4} "${FLAGS[@]}" -o "${SEEDX_DIR}" SeedPython.g4


### PR DESCRIPTION
The block parser can parse text source code of block programs and convert text expression source code to a list of BaseBlock.