### PR TITLE
Add NuGet package metadata

### DIFF
--- a/csharp/src/SeedLang.Shell/SeedLang.Shell.csproj
+++ b/csharp/src/SeedLang.Shell/SeedLang.Shell.csproj
@@ -1,5 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <PackageId>SeedLang.Shell</PackageId>
+    <Version>0.1.1</Version>
+    <Authors>The Aha001 Team</Authors>
+    <Company>SeedV.com</Company>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/aha-001/SeedLang</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <Description>SeedLang is a visualizable low-code programming environment that focuses on educational purposes.</Description>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SeedLang\SeedLang.csproj" />
   </ItemGroup>
@@ -7,10 +20,5 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-  </PropertyGroup>
 
 </Project>

--- a/csharp/src/SeedLang/SeedLang.csproj
+++ b/csharp/src/SeedLang/SeedLang.csproj
@@ -2,6 +2,14 @@
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <PackageId>SeedLang</PackageId>
+    <Version>0.1.1</Version>
+    <Authors>The Aha001 Team</Authors>
+    <Company>SeedV.com</Company>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/aha-001/SeedLang</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <Description>SeedLang is a visualizable low-code programming environment that focuses on educational purposes.</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add metadata so that SeedLang can be published to NuGet manually. Will add a versioning and publishing script to aotumate the process.

See the published versions at https://www.nuget.org/packages/SeedLang/

It sounds like a promising way to publish SeedLang to NuGet first then import the package to Unity (via a third-party extension, https://github.com/GlitchEnzo/NuGetForUnity). Although, there is still an unsolved dependency - System.Text.Json is failed to run in Unity - I will do more tests and try to fix it (e.g. by reverting back to Newtonsoft.Json) shortly.