### PR TITLE
Revert back from System.Text.Json to Newtonsoft.Json

### DIFF
--- a/csharp/src/SeedLang/Block/BxfConstants.cs
+++ b/csharp/src/SeedLang/Block/BxfConstants.cs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
-
 namespace SeedLang.Block {
   // Common settings used by the Block Exchange Format.
   public static class BxfConstants {
@@ -33,15 +30,5 @@ namespace SeedLang.Block {
     public const string DefaultOperatorName = "+";
     public const string LeftParenthsis = "(";
     public const string RightParenthsis = ")";
-
-    // The serialization options used by BxfWriter and BxfReader.
-    public static JsonSerializerOptions JsonOptions { get; set; } = new JsonSerializerOptions {
-      Converters = {
-        new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)
-      },
-      IgnoreNullValues = true,
-      PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-      WriteIndented = true,
-    };
   }
 }

--- a/csharp/src/SeedLang/Block/BxfObject.cs
+++ b/csharp/src/SeedLang/Block/BxfObject.cs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 using System.Collections.Generic;
 
 namespace SeedLang.Block {
@@ -23,6 +26,9 @@ namespace SeedLang.Block {
   //
   // TODO: It's possible to build an auto-generator to create the following C# code based on
   // /schemas/bxf.schema.json. Consider this possibility in the future.
+  [JsonObject(
+      ItemNullValueHandling = NullValueHandling.Ignore,
+      NamingStrategyType = typeof(CamelCaseNamingStrategy))]
   internal class BxfObject {
     public string Schema { get; set; } = BxfConstants.Schema;
     public string Version { get; set; } = BxfConstants.Version;
@@ -32,12 +38,18 @@ namespace SeedLang.Block {
     public BxfModule Module { get; set; } = new BxfModule();
   }
 
+  [JsonObject(
+      ItemNullValueHandling = NullValueHandling.Ignore,
+      NamingStrategyType = typeof(CamelCaseNamingStrategy))]
   internal class BxfModule {
     public string Name { get; set; } = null;
     public string Doc { get; set; } = null;
     public List<BxfBlock> Blocks { get; set; } = new List<BxfBlock>();
   }
 
+  [JsonObject(
+      ItemNullValueHandling = NullValueHandling.Ignore,
+      NamingStrategyType = typeof(CamelCaseNamingStrategy))]
   internal class BxfBlock {
     public string Id { get; set; } = null;
     public string Type { get; set; } = null;
@@ -87,13 +99,20 @@ namespace SeedLang.Block {
     }
   }
 
+  [JsonObject(
+      ItemNullValueHandling = NullValueHandling.Ignore,
+      NamingStrategyType = typeof(CamelCaseNamingStrategy))]
   internal class BxfCanvasPosition {
     public int X { get; set; } = 0;
     public int Y { get; set; } = 0;
   }
 
+  [JsonObject(
+      ItemNullValueHandling = NullValueHandling.Ignore,
+      NamingStrategyType = typeof(CamelCaseNamingStrategy))]
   internal class BxfDockPosition {
     public string TargetBlockId { get; set; } = null;
+    [JsonConverter(typeof(StringEnumConverter), true)]
     public Position.DockType DockType { get; set; }
     public int DockSlotIndex { get; set; } = 0;
   }

--- a/csharp/src/SeedLang/Block/BxfReader.cs
+++ b/csharp/src/SeedLang/Block/BxfReader.cs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using SeedLang.Common;
 using System.IO;
-using System.Text.Json;
 
 namespace SeedLang.Block {
   // The utilities to parse BXF JSON strings or files.
@@ -36,7 +36,7 @@ namespace SeedLang.Block {
       // TODO: Consider supporting async operation since this operation may cost some time.
       BxfObject bxfObject;
       try {
-        bxfObject = JsonSerializer.Deserialize<BxfObject>(json, BxfConstants.JsonOptions);
+        bxfObject = JsonConvert.DeserializeObject<BxfObject>(json);
       } catch (JsonException e) {
         diagnosticCollection.Report(
             new Diagnostic(SystemReporters.SeedBlock, Severity.Fatal, null, null,

--- a/csharp/src/SeedLang/Block/BxfWriter.cs
+++ b/csharp/src/SeedLang/Block/BxfWriter.cs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Newtonsoft.Json;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.Json;
 
 namespace SeedLang.Block {
   // The utility to generate Bxf JSON strings or files.
@@ -69,7 +69,7 @@ namespace SeedLang.Block {
         rootBlock.Accept(blockCollector);
       }
       try {
-        return JsonSerializer.Serialize(obj, BxfConstants.JsonOptions);
+        return JsonConvert.SerializeObject(obj, Formatting.Indented);
       } catch (JsonException e) {
         // Must not run into this since WriteToString is a pure internal data serialization.
         Debug.Fail($"Serialization failed: {e}");

--- a/csharp/src/SeedLang/SeedLang.csproj
+++ b/csharp/src/SeedLang/SeedLang.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.9.2" />
     <PackageReference Include="Antlr4BuildTasks" Version="8.15">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/src/SeedLang/SeedLang.csproj
+++ b/csharp/src/SeedLang/SeedLang.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.9.2" />
     <PackageReference Include="Antlr4BuildTasks" Version="8.15">
       <PrivateAssets>all</PrivateAssets>
@@ -28,10 +29,6 @@
         <Error>true</Error>
         <LibPath>../../../grammars</LibPath>
     </Antlr4>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/tests/SeedLang.Tests/Block/BxfTests.cs
+++ b/csharp/tests/SeedLang.Tests/Block/BxfTests.cs
@@ -385,40 +385,6 @@ namespace SeedLang.Block.Tests {
     }
 
     [Fact]
-    public void TestInvalidType() {
-      // Microsoft System.Text.Json throws out "InvalidJson The JSON value could not be converted to
-      // System.Int32. Path: $.module.blocks[0].canvasPosition.x ..." for the input, while
-      // Newtonsoft.Json ignores the error by default.
-      //
-      // When using Newtonsoft.Json, Please turn on strict deserialization to pass this test.
-      string json = @"
-{
-  ""schema"": ""bxf"",
-  ""version"": ""v0.1"",
-  ""module"": {
-    ""name"": ""Main"",
-    ""blocks"": [
-      {
-        ""id"": ""00000000"",
-        ""type"": ""number"",
-        ""doc"": """",
-        ""content"": ""5"",
-        ""canvasPosition"": {
-          ""x"": ""0"",
-          ""y"": ""0""
-        }
-      }
-    ]
-  }
-}";
-      var diagnosticCollection = new DiagnosticCollection();
-      var moduleParsed = BxfReader.ReadFromString(json, diagnosticCollection);
-      Assert.Null(moduleParsed);
-      Assert.Single(diagnosticCollection.Diagnostics);
-      Assert.Equal(Severity.Fatal, diagnosticCollection.Diagnostics[0].Severity);
-    }
-
-    [Fact]
     public void TestTargetBlockNotDockable1() {
       string json = @"
 {


### PR DESCRIPTION
Unity has no official support of .Net 5.0 for now. Although it's possible to import NuGet package System.Text.Json for netstandard 2.0, the dependencies are very complex and hard to maintain. We have to manually choose and import 7 DLLs and disable "Validate References" for them in Unity.

With the solution to depend on Newtonsoft.Json, it's easy to import SeedLang.dll to Unity project without importing Newtonsoft.Json since Unity already provides one by default.

Please take a look at the experimental branch https://github.com/aha-001/SeedCalc/tree/wip_wixette_integration to see how to import SeedLang.dll into a Unity project and run a SeedLang executor in Unity scripts.

There are behavior differences between System.Text.Json and Newtonsoft.Json, especially in the strict deserialization features. And it needs non-trivial effort to keep the same behavior with Newtonsoft.Json. But I think it's okay to stay with the default behavior of Newtonsoft.Json considering the needs of SeedLang.