### PR TITLE
Include MessageId in Diagnostic. Closes #62

### DIFF
--- a/csharp/src/SeedLang/Block/Converter.cs
+++ b/csharp/src/SeedLang/Block/Converter.cs
@@ -66,8 +66,8 @@ namespace SeedLang.Block {
     // collection if the text is invalid.
     public static bool IsValidInlineTextExpression(string text, DiagnosticCollection collection) {
       if (string.IsNullOrEmpty(text)) {
-        collection.Report(new Diagnostic(SystemReporters.SeedBlock, Severity.Error, null, null,
-                                         Message.EmptyInlineText.ToString()));
+        collection.Report(SystemReporters.SeedBlock, Severity.Error, null, null,
+                          Message.EmptyInlineText);
         return false;
       }
       var parser = new InlineTextParser();
@@ -79,8 +79,8 @@ namespace SeedLang.Block {
     public static IReadOnlyList<BaseBlock> InlineTextToBlocks(
         string text, IList<TextRange> invalidTokenRanges, DiagnosticCollection collection) {
       if (string.IsNullOrEmpty(text)) {
-        collection.Report(new Diagnostic(SystemReporters.SeedBlock, Severity.Error, null, null,
-                                         Message.EmptyInlineText.ToString()));
+        collection.Report(SystemReporters.SeedBlock, Severity.Error, null, null,
+                          Message.EmptyInlineText);
         return null;
       }
       var parser = new InlineTextParser();

--- a/csharp/src/SeedLang/Block/IEditable.cs
+++ b/csharp/src/SeedLang/Block/IEditable.cs
@@ -20,7 +20,7 @@ namespace SeedLang.Block {
 
     // Updates the block content with a new plain text code.
     //
-    // Throws a new ArgumentException if the input is not a valid text.
+    // Throws a new DiagnosticException if the input is not a valid text.
     void UpdateText(string text);
   }
 }

--- a/csharp/src/SeedLang/Block/Module.cs
+++ b/csharp/src/SeedLang/Block/Module.cs
@@ -138,9 +138,15 @@ namespace SeedLang.Block {
           (targetBlock as IDockable).CanDock(block, type, dockSlotIndex)) {
         (targetBlock as IDockable).Dock(block, type, dockSlotIndex);
       } else {
-        throw new ArgumentException(Message.TargetBlockNotDockable4.Format(
-            blockId, targetBlockId, Enum.GetName(typeof(Position.DockType), type),
-            dockSlotIndex.ToString()));
+        throw new DiagnosticException(SystemReporters.SeedBlock,
+                                      Severity.Fatal,
+                                      Name,
+                                      new BlockRange(blockId),
+                                      Message.TargetBlockNotDockable4,
+                                      blockId,
+                                      targetBlockId,
+                                      Enum.GetName(typeof(Position.DockType), type),
+                                      dockSlotIndex.ToString());
       }
     }
 
@@ -201,8 +207,12 @@ namespace SeedLang.Block {
       foreach (var block in blocks) {
         if (block.Pos.IsDocked) {
           if (!_blocks.ContainsKey(block.Pos.TargetBlockId)) {
-            throw new ArgumentException(
-                Message.TargetBlockIdNotExist1.Format(block.Pos.TargetBlockId));
+            throw new DiagnosticException(SystemReporters.SeedBlock,
+                                          Severity.Fatal,
+                                          Name,
+                                          new BlockRange(new BlockPosition(block.Id)),
+                                          Message.TargetBlockIdNotExist1,
+                                          block.Pos.TargetBlockId);
           } else {
             var idGroups = dockingGraph[block.Pos.TargetBlockId];
             switch (block.Pos.Type) {

--- a/csharp/src/SeedLang/Block/OperatorBlock.cs
+++ b/csharp/src/SeedLang/Block/OperatorBlock.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using SeedLang.Common;
 
 namespace SeedLang.Block {
@@ -37,7 +36,14 @@ namespace SeedLang.Block {
       if (ValidateText(text)) {
         _name = text;
       } else {
-        throw new ArgumentException(Message.InvalidOperatorName1.Format(text));
+        // The thrown exception has no module name associated, since there is no block-to-module
+        // mapping for now. It depends on the outside logic to fill the info in.
+        //
+        // TODO: a better solution to fill the module name in.
+        throw new DiagnosticException(SystemReporters.SeedBlock, Severity.Error,
+                                      null,
+                                      new BlockRange(Id),
+                                      Message.InvalidOperatorName1, text);
       }
     }
 

--- a/csharp/src/SeedLang/Block/PrimitiveValueBlock.cs
+++ b/csharp/src/SeedLang/Block/PrimitiveValueBlock.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using SeedLang.Common;
 
 namespace SeedLang.Block {
@@ -37,7 +36,14 @@ namespace SeedLang.Block {
       if (ValidateText(text)) {
         _value = text;
       } else {
-        throw new ArgumentException(Message.InvalidPrimitiveValue1.Format(text));
+        // The thrown exception has no module name associated, since there is no block-to-module
+        // mapping for now. It depends on the outside logic to fill the info in.
+        //
+        // TODO: a better solution to fill the module name in.
+        throw new DiagnosticException(SystemReporters.SeedBlock, Severity.Error,
+                                      null,
+                                      new BlockRange(Id),
+                                      Message.InvalidPrimitiveValue1, text);
       }
     }
 

--- a/csharp/src/SeedLang/Common/Diagnostic.cs
+++ b/csharp/src/SeedLang/Common/Diagnostic.cs
@@ -24,7 +24,7 @@ namespace SeedLang.Common {
     public const string SeedVM = "SeedLang.VM";
   }
 
-  // An immutable dignostic info, such as a compiler error or warning.
+  // A dignostic info, such as a compiler error or warning.
   public sealed class Diagnostic {
     // The name of the reporter.
     //
@@ -33,29 +33,37 @@ namespace SeedLang.Common {
     //
     // Third-party extensions that report diagnostics will be named as "Contributor.ExtensionName".
     // There will be an ExtensionHelper to help format reporter names.
-    public string Reporter { get; }
+    public string Reporter { get; set; }
     // The time that the diagnostic is reported.
-    public string Timestamp { get; }
+    public string Timestamp { get; set; }
     // The severity of the diagnostic.
-    public Severity Severity { get; }
+    public Severity Severity { get; set; }
     // The name of the source code module.
-    public string Module { get; }
+    public string Module { get; set; }
     // The corresponding code range of the diagnostic.
-    public Range Range { get; }
+    public Range Range { get; set; }
+    // The ID of the message. For now, message IDs are the values of the enum type Message. The ID
+    // of a message is unique but not stable, since the messages in the enum is arranged in
+    // alphabetical order.
+    //
+    // TODO: Do we need stable message IDs?
+    public Message MessageId { get; set; }
     // The string message. This message should be localized and formatted by the
     // SeedLang.Common.Message type.
-    public string LocalizedMessage { get; }
+    public string LocalizedMessage { get; set; }
 
     public Diagnostic(string reporter,
                       Severity severity,
                       string module,
                       Range range,
+                      Message messageId,
                       string localizedMessage) {
       Reporter = reporter;
       Timestamp = Utils.Timestamp();
       Severity = severity;
       Module = module;
       Range = range;
+      MessageId = messageId;
       LocalizedMessage = localizedMessage;
     }
 
@@ -65,7 +73,7 @@ namespace SeedLang.Common {
       sb.AppendFormat(" {0}", Enum.GetName(typeof(Severity), Severity));
       sb.AppendFormat(" ({0}) <{1}> ", Reporter, Module);
       sb.Append(Range is null ? "[]" : Range.ToString());
-      sb.AppendFormat(": {0}", LocalizedMessage);
+      sb.AppendFormat(" {0}: {1}", (int)MessageId, LocalizedMessage);
       return sb.ToString();
     }
   }

--- a/csharp/src/SeedLang/Common/DiagnosticCollection.cs
+++ b/csharp/src/SeedLang/Common/DiagnosticCollection.cs
@@ -47,5 +47,26 @@ namespace SeedLang.Common {
     public void Report(Diagnostic diagnostic) {
       _diagnostics.Add(diagnostic);
     }
+
+    // Reports a new diagnostic, with a message that requires no arguments.
+    public void Report(string reporter,
+                       Severity severity,
+                       string module,
+                       Range range,
+                       Message messageId) {
+      _diagnostics.Add(
+        new Diagnostic(reporter, severity, module, range, messageId, messageId.Format()));
+    }
+
+    // Reports a new diagnostic, with a message that requires one or more arguments to be formatted.
+    public void Report(string reporter,
+                       Severity severity,
+                       string module,
+                       Range range,
+                       Message messageId,
+                       params string[] arguments) {
+      _diagnostics.Add(
+        new Diagnostic(reporter, severity, module, range, messageId, messageId.Format(arguments)));
+    }
   }
 }

--- a/csharp/src/SeedLang/Common/DiagnosticException.cs
+++ b/csharp/src/SeedLang/Common/DiagnosticException.cs
@@ -1,0 +1,56 @@
+// Copyright 2021 The Aha001 Team.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace SeedLang.Common {
+  // An exception that contains a diagnostic info.
+  //
+  // This exception is only used for throwing exceptions among underlying components.
+  //
+  // When reporting diagnostics via SeedLang's public API, please let users to pass in a
+  // DiagnosticCollection instance. For example:
+  //
+  // public bool DoSomthing(int someParameter, DiagnosticCollection collection) {
+  //   try {
+  //     DoSomethingInternally();
+  //   } catch (DiagnosticException e) {
+  //     collection.Report(e.Diagnostic);
+  //     return false;
+  //   }
+  //   return true;
+  // }
+  internal class DiagnosticException : Exception {
+    public Diagnostic Diagnostic { get; private set; }
+
+    public DiagnosticException(string reporter,
+                               Severity severity,
+                               string module,
+                               Range range,
+                               Message messageId) {
+      Diagnostic =
+          new Diagnostic(reporter, severity, module, range, messageId, messageId.Format());
+    }
+
+    public DiagnosticException(string reporter,
+                               Severity severity,
+                               string module,
+                               Range range,
+                               Message messageId,
+                               params string[] arguments) {
+      Diagnostic =
+          new Diagnostic(reporter, severity, module, range, messageId, messageId.Format(arguments));
+    }
+  }
+}

--- a/csharp/src/SeedLang/X/SyntaxErrorStrategy.cs
+++ b/csharp/src/SeedLang/X/SyntaxErrorStrategy.cs
@@ -43,7 +43,7 @@ namespace SeedLang.X {
               tokens = EscapeWSAndQuote(tokens);
               ReportDiagnostic(
                   CodeReferenceUtils.RangeOfTokens(exception.StartToken, exception.OffendingToken),
-                  Message.SyntaxErrorNoViableAlternative1.Format(tokens));
+                  Message.SyntaxErrorNoViableAlternative1, tokens);
             }
             break;
           case InputMismatchException ime:
@@ -53,7 +53,7 @@ namespace SeedLang.X {
             string ruleName = parser.RuleNames[parser.RuleContext.RuleIndex];
             ReportDiagnostic(
                 CodeReferenceUtils.RangeOfTokens(fpe.OffendingToken, fpe.OffendingToken),
-                Message.SyntaxErrorFailedPredicate1.Format(ruleName));
+                Message.SyntaxErrorFailedPredicate1, ruleName);
             break;
           default:
             Debug.Fail("Unsupported recognition exception.");
@@ -84,15 +84,15 @@ namespace SeedLang.X {
       return false;
     }
 
-    private void ReportDiagnostic(Range range, string message) {
-      _collection.Report(
-        new Diagnostic(SystemReporters.SeedX, Severity.Fatal, _module, range, message));
+    private void ReportDiagnostic(Range range, Message messageId, params string[] arguments) {
+      _collection.Report(SystemReporters.SeedX, Severity.Fatal, _module, range, messageId,
+                         arguments);
     }
 
-    private void ReportDiagnosticForToken(Parser parser, IToken token, Message message) {
+    private void ReportDiagnosticForToken(Parser parser, IToken token, Message messageId) {
       string expectedTokens = GetExpectedTokens(parser).ToString(parser.Vocabulary);
       ReportDiagnostic(CodeReferenceUtils.RangeOfTokens(token, token),
-                       message.Format(GetTokenErrorDisplay(token), expectedTokens));
+                       messageId, GetTokenErrorDisplay(token), expectedTokens);
     }
   }
 }

--- a/csharp/tests/SeedLang.Tests/Common/DiagnosticCollectionTests.cs
+++ b/csharp/tests/SeedLang.Tests/Common/DiagnosticCollectionTests.cs
@@ -22,36 +22,54 @@ namespace SeedLang.Common.Tests {
       var collection = new DiagnosticCollection();
       Assert.Empty(collection.Diagnostics);
       collection.Report(
-          new Diagnostic(SystemReporters.SeedAst, Severity.Error,
-                         "module1", null,
+          new Diagnostic(SystemReporters.SeedAst,
+                         Severity.Error,
+                         "module1",
+                         null,
+                         Message.Okay,
                          Message.Okay.Get()));
       Assert.Single(collection.Diagnostics);
-      collection.Report(
-          new Diagnostic(SystemReporters.SeedBlock, Severity.Warning,
-                         "module2", null,
-                         Message.Okay.Get()));
+      collection.Report(SystemReporters.SeedBlock,
+                        Severity.Warning,
+                        "module2",
+                        null,
+                        Message.Okay);
       Assert.Equal(2, collection.Diagnostics.Count);
+      collection.Report(SystemReporters.SeedBlock,
+                        Severity.Warning,
+                        "module3",
+                        null,
+                        Message.ExampleMessageWithOneArgument1,
+                        "arg1");
+      Assert.Equal(3, collection.Diagnostics.Count);
+      Assert.Contains("arg1", collection.Diagnostics[2].LocalizedMessage);
+      collection.Report(SystemReporters.SeedBlock,
+                        Severity.Warning,
+                        "module4",
+                        null,
+                        Message.ExampleMessageWithTwoArguments2,
+                        "arg1",
+                        "arg2");
+      Assert.Equal(4, collection.Diagnostics.Count);
+      Assert.Contains("arg1", collection.Diagnostics[3].LocalizedMessage);
+      Assert.Contains("arg2", collection.Diagnostics[3].LocalizedMessage);
     }
 
     [Fact]
     public void TestLinqQueries() {
       var collection = new DiagnosticCollection();
-      collection.Report(
-          new Diagnostic(SystemReporters.SeedAst, Severity.Error,
-                         "module1", null,
-                         Message.Okay.Get()));
-      collection.Report(
-          new Diagnostic(SystemReporters.SeedAst, Severity.Info,
-                         "module2", null,
-                         Message.Okay.Get()));
-      collection.Report(
-          new Diagnostic(SystemReporters.SeedBlock, Severity.Fatal,
-                         "module3", null,
-                         Message.Okay.Get()));
-      collection.Report(
-          new Diagnostic(SystemReporters.SeedBlock, Severity.Warning,
-                         "module4", null,
-                         Message.Okay.Get()));
+      collection.Report(SystemReporters.SeedAst, Severity.Error,
+                        "module1", null,
+                        Message.Okay);
+      collection.Report(SystemReporters.SeedAst, Severity.Info,
+                        "module2", null,
+                        Message.Okay);
+      collection.Report(SystemReporters.SeedBlock, Severity.Fatal,
+                        "module3", null,
+                        Message.Okay);
+      collection.Report(SystemReporters.SeedBlock, Severity.Warning,
+                        "module4", null,
+                        Message.Okay);
       var query1 = from diagnostic in collection.Diagnostics
                    where diagnostic.Reporter == SystemReporters.SeedAst &&
                          diagnostic.Severity == Severity.Error

--- a/csharp/tests/SeedLang.Tests/Common/DiagnosticExceptionTests.cs
+++ b/csharp/tests/SeedLang.Tests/Common/DiagnosticExceptionTests.cs
@@ -1,0 +1,38 @@
+// Copyright 2021 The Aha001 Team.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace SeedLang.Common.Tests {
+  public class DiagnosticExceptionTests {
+    [Fact]
+    public void TestDiagnosticException() {
+      try {
+        throw new DiagnosticException(SystemReporters.SeedBlock, Severity.Error, "Main",
+                                      new BlockRange("1"), Message.Okay);
+      } catch (DiagnosticException e) {
+        Assert.Equal(e.Diagnostic.Range, new BlockRange("1"));
+        Assert.Equal(Message.Okay, e.Diagnostic.MessageId);
+      }
+
+      try {
+        throw new DiagnosticException(SystemReporters.SeedBlock, Severity.Error, "Main",
+                                      new BlockRange("2"),
+                                      Message.ExampleMessageWithOneArgument1, "arg1");
+      } catch (DiagnosticException e) {
+        Assert.Contains("arg1", e.Diagnostic.LocalizedMessage);
+      }
+    }
+  }
+}

--- a/csharp/tests/SeedLang.Tests/Common/DiagnosticTests.cs
+++ b/csharp/tests/SeedLang.Tests/Common/DiagnosticTests.cs
@@ -19,15 +19,16 @@ namespace SeedLang.Common.Tests {
     [Fact]
     public void TestDiagnosticToString() {
       string ts = Utils.Timestamp();
-      var diagnostic = new Diagnostic(null, Severity.Error, null, null, null);
-      Assert.Equal("Error () <> []: ", diagnostic.ToString().Substring(ts.Length + 1));
+      var diagnostic = new Diagnostic(null, Severity.Error, null, null, Message.Okay, null);
+      Assert.Equal("Error () <> [] 0: ", diagnostic.ToString().Substring(ts.Length + 1));
       diagnostic = new Diagnostic(SystemReporters.SeedBlock, Severity.Info,
-                                  "main", null, "A sample message.");
-      Assert.Equal("Info (SeedLang.Block) <main> []: A sample message.",
+                                  "main", null, Message.Okay, "A sample message.");
+      Assert.Equal("Info (SeedLang.Block) <main> [] 0: A sample message.",
                    diagnostic.ToString().Substring(ts.Length + 1));
       diagnostic = new Diagnostic(SystemReporters.SeedX, Severity.Info,
-                                  "main", new TextRange(1, 1, 1, 3), "A sample message.");
-      Assert.Equal("Info (SeedLang.X) <main> [Ln 1, Col 1 - Ln 1, Col 3]: A sample message.",
+                                  "main", new TextRange(1, 1, 1, 3),
+                                  Message.Okay, "A sample message.");
+      Assert.Equal("Info (SeedLang.X) <main> [Ln 1, Col 1 - Ln 1, Col 3] 0: A sample message.",
                    diagnostic.ToString().Substring(ts.Length + 1));
     }
   }


### PR DESCRIPTION
* Add MessageId to Diagnostic
* Refactor DiagnosticCollection to make reporting easier
* Add DiagnosticException for internal components to throw diagnostics
* Make Diagnostic mutable so that outside logic can refill info in
  after catching a diagnostic via an exception (a temp solution)