### PR TITLE
Add source code range information in all AST nodes

### DIFF
--- a/csharp/src/SeedLang.Shell/Repl.cs
+++ b/csharp/src/SeedLang.Shell/Repl.cs
@@ -60,17 +60,16 @@ namespace SeedLang.Shell {
       }
 
       private void WriteSource(TextRange range) {
-        if (range.Start.Column >= 0 && range.Start.Column <= range.End.Column &&
-            range.End.Column < Source.Length) {
-          Console.Write(Source.Substring(0, range.Start.Column));
-          Console.BackgroundColor = ConsoleColor.DarkCyan;
-          Console.ForegroundColor = ConsoleColor.Black;
-          int length = range.End.Column - range.Start.Column + 1;
-          Console.Write(Source.Substring(range.Start.Column, length));
-          Console.ResetColor();
-          Console.Write(Source.Substring(range.End.Column + 1));
-          Console.Write(": ");
-        }
+        Debug.Assert(range.Start.Column >= 0 && range.Start.Column <= range.End.Column &&
+                     range.End.Column < Source.Length);
+        Console.Write(Source.Substring(0, range.Start.Column));
+        Console.BackgroundColor = ConsoleColor.DarkCyan;
+        Console.ForegroundColor = ConsoleColor.Black;
+        int length = range.End.Column - range.Start.Column + 1;
+        Console.Write(Source.Substring(range.Start.Column, length));
+        Console.ResetColor();
+        Console.Write(Source.Substring(range.End.Column + 1));
+        Console.Write(": ");
       }
     }
 

--- a/csharp/src/SeedLang/Ast/AstNode.cs
+++ b/csharp/src/SeedLang/Ast/AstNode.cs
@@ -17,7 +17,7 @@ using SeedLang.Common;
 namespace SeedLang.Ast {
   // The base class of all AST nodes.
   internal abstract class AstNode {
-    // The source range of this AST node.
+    // The source code range of this AST node. It could be BlockRange or TextRange.
     public Range Range { get; }
 
     internal AstNode(Range range) {

--- a/csharp/src/SeedLang/Ast/AstNode.cs
+++ b/csharp/src/SeedLang/Ast/AstNode.cs
@@ -12,9 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using SeedLang.Common;
+
 namespace SeedLang.Ast {
   // The base class of all AST nodes.
   internal abstract class AstNode {
+    // The source range of this AST node.
+    public Range Range { get; }
+
+    internal AstNode(Range range) {
+      Range = range;
+    }
+
     // Creates the string representation of the AST node.
     public override string ToString() {
       return AstStringBuilder.AstToString(this);

--- a/csharp/src/SeedLang/Ast/AstStringBuilder.cs
+++ b/csharp/src/SeedLang/Ast/AstStringBuilder.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Diagnostics;
 using System.Text;
 using SeedLang.Runtime;
 
@@ -64,7 +63,6 @@ namespace SeedLang.Ast {
 
     // Outputs a given AST tree to a string.
     internal static string AstToString(AstNode node) {
-      Debug.Assert(node != null);
       var asb = new AstStringBuilder();
       asb.Visit(node);
       return asb.ToString();

--- a/csharp/src/SeedLang/Ast/Executor.cs
+++ b/csharp/src/SeedLang/Ast/Executor.cs
@@ -62,8 +62,8 @@ namespace SeedLang.Ast {
           Debug.Fail($"Unsupported binary operator: {binary.Op}");
           break;
       }
-      _visualizerCenter.BinaryPublisher.Notify(
-          new BinaryEvent(left, binary.Op, right, _expressionResult));
+      var be = new BinaryEvent(left, binary.Op, right, _expressionResult, binary.Range);
+      _visualizerCenter.BinaryPublisher.Notify(be);
     }
 
     protected override void Visit(IdentifierExpression identifier) {
@@ -93,13 +93,14 @@ namespace SeedLang.Ast {
     protected override void Visit(AssignmentStatement assignment) {
       Visit(assignment.Expr);
       _globals[assignment.Identifier.Name] = _expressionResult;
-      var e = new AssignmentEvent(assignment.Identifier.Name, _expressionResult);
-      _visualizerCenter.AssignmentPublisher.Notify(e);
+      var ae = new AssignmentEvent(assignment.Identifier.Name, _expressionResult, assignment.Range);
+      _visualizerCenter.AssignmentPublisher.Notify(ae);
     }
 
     protected override void Visit(EvalStatement eval) {
       Visit(eval.Expr);
-      _visualizerCenter.EvalPublisher.Notify(new EvalEvent(_expressionResult));
+      var ee = new EvalEvent(_expressionResult, eval.Range);
+      _visualizerCenter.EvalPublisher.Notify(ee);
     }
   }
 }

--- a/csharp/src/SeedLang/Ast/Expressions.cs
+++ b/csharp/src/SeedLang/Ast/Expressions.cs
@@ -12,53 +12,58 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
+using SeedLang.Common;
 using SeedLang.Runtime;
 
 namespace SeedLang.Ast {
   // The base class of all expression nodes.
   internal abstract class Expression : AstNode {
     // The factory method to create a binary expression.
-    internal static BinaryExpression Binary(Expression left, BinaryOperator op, Expression right) {
-      return new BinaryExpression(left, op, right);
+    internal static BinaryExpression Binary(Expression left, BinaryOperator op, Expression right,
+                                            Range range) {
+      return new BinaryExpression(left, op, right, range);
     }
 
     // The factory method to create an identifier expression.
-    internal static IdentifierExpression Identifier(string name) {
-      return new IdentifierExpression(name);
+    internal static IdentifierExpression Identifier(string name, Range range) {
+      return new IdentifierExpression(name, range);
     }
 
     // The factory method to create a number constant expression from a string.
-    internal static NumberConstantExpression Number(string valueStr) {
+    internal static NumberConstantExpression Number(string value, Range range) {
       try {
-        return Number(double.Parse(valueStr));
-      } catch (Exception) {
-        return Number(0);
+        return Number(double.Parse(value), range);
+      } catch (System.Exception) {
+        return Number(0, range);
       }
     }
 
     // The factory method to create a number constant expression.
-    internal static NumberConstantExpression Number(double value) {
-      return new NumberConstantExpression(value);
+    internal static NumberConstantExpression Number(double value, Range range) {
+      return new NumberConstantExpression(value, range);
     }
 
     // The factory method to create a string constant expression.
-    internal static StringConstantExpression String(string value) {
-      return new StringConstantExpression(value);
+    internal static StringConstantExpression String(string value, Range range) {
+      return new StringConstantExpression(value, range);
     }
 
     // The factory method to create a unary expression.
-    internal static UnaryExpression Unary(UnaryOperator op, Expression expr) {
-      return new UnaryExpression(op, expr);
+    internal static UnaryExpression Unary(UnaryOperator op, Expression expr, Range range) {
+      return new UnaryExpression(op, expr, range);
+    }
+
+    internal Expression(Range range) : base(range) {
     }
   }
 
   internal class BinaryExpression : Expression {
-    public Expression Left { get; set; }
-    public BinaryOperator Op { get; set; }
-    public Expression Right { get; set; }
+    public Expression Left { get; }
+    public BinaryOperator Op { get; }
+    public Expression Right { get; }
 
-    internal BinaryExpression(Expression left, BinaryOperator op, Expression right) {
+    internal BinaryExpression(Expression left, BinaryOperator op, Expression right,
+                              Range range) : base(range) {
       Left = left;
       Op = op;
       Right = right;
@@ -66,34 +71,34 @@ namespace SeedLang.Ast {
   }
 
   internal class IdentifierExpression : Expression {
-    public string Name { get; set; }
+    public string Name { get; }
 
-    internal IdentifierExpression(string name) {
+    internal IdentifierExpression(string name, Range range) : base(range) {
       Name = name;
     }
   }
 
   internal class NumberConstantExpression : Expression {
-    public double Value { get; set; }
+    public double Value { get; }
 
-    internal NumberConstantExpression(double value) {
+    internal NumberConstantExpression(double value, Range range) : base(range) {
       Value = value;
     }
   }
 
   internal class StringConstantExpression : Expression {
-    public string Value { get; set; }
+    public string Value { get; }
 
-    internal StringConstantExpression(string value) {
+    internal StringConstantExpression(string value, Range range) : base(range) {
       Value = value;
     }
   }
 
   internal class UnaryExpression : Expression {
-    public UnaryOperator Op { get; set; }
-    public Expression Expr { get; set; }
+    public UnaryOperator Op { get; }
+    public Expression Expr { get; }
 
-    internal UnaryExpression(UnaryOperator op, Expression expr) {
+    internal UnaryExpression(UnaryOperator op, Expression expr, Range range) : base(range) {
       Op = op;
       Expr = expr;
     }

--- a/csharp/src/SeedLang/Ast/Statements.cs
+++ b/csharp/src/SeedLang/Ast/Statements.cs
@@ -12,17 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using SeedLang.Common;
+
 namespace SeedLang.Ast {
   // The base class of all statement nodes.
   internal abstract class Statement : AstNode {
     // The factory method to creates the assignment statement.
-    internal static AssignmentStatement Assignment(IdentifierExpression identifier, Expression expr) {
-      return new AssignmentStatement(identifier, expr);
+    internal static AssignmentStatement Assignment(IdentifierExpression identifier, Expression expr,
+                                                   Range range) {
+      return new AssignmentStatement(identifier, expr, range);
     }
 
     // The factory method to creates the eval statement.
-    internal static EvalStatement Eval(Expression expr) {
-      return new EvalStatement(expr);
+    internal static EvalStatement Eval(Expression expr, Range range) {
+      return new EvalStatement(expr, range);
+    }
+
+    internal Statement(Range range) : base(range) {
     }
   }
 
@@ -30,7 +36,8 @@ namespace SeedLang.Ast {
     public IdentifierExpression Identifier { get; }
     public Expression Expr { get; }
 
-    internal AssignmentStatement(IdentifierExpression identifier, Expression expr) {
+    internal AssignmentStatement(IdentifierExpression identifier, Expression expr,
+                                 Range range) : base(range) {
       Identifier = identifier;
       Expr = expr;
     }
@@ -39,7 +46,7 @@ namespace SeedLang.Ast {
   internal class EvalStatement : Statement {
     public Expression Expr { get; }
 
-    internal EvalStatement(Expression expr) {
+    internal EvalStatement(Expression expr, Range range) : base(range) {
       Expr = expr;
     }
   }

--- a/csharp/src/SeedLang/Block/InlineTextVisitor.cs
+++ b/csharp/src/SeedLang/Block/InlineTextVisitor.cs
@@ -27,22 +27,24 @@ namespace SeedLang.Block {
   // result of the last one. InlineTextVisitor overrides the method if the default implement is not
   // correct.
   internal class InlineTextVisitor : SeedBlockBaseVisitor<AstNode> {
+    private readonly VisitorHelper _helper = new VisitorHelper();
+
     // Visits a single identifier.
     public override AstNode VisitSingle_identifier(
         [NotNull] SeedBlockParser.Single_identifierContext context) {
-      return VisitorHelper.BuildIdentifier(context.IDENTIFIER().Symbol);
+      return _helper.BuildIdentifier(context.IDENTIFIER().Symbol);
     }
 
     // Visits a single number.
     public override AstNode VisitSingle_number(
         [NotNull] SeedBlockParser.Single_numberContext context) {
-      return VisitorHelper.BuildNumber(context.NUMBER().Symbol);
+      return _helper.BuildNumber(context.NUMBER().Symbol);
     }
 
     // Visits a single string.
     public override AstNode VisitSingle_string(
         [NotNull] SeedBlockParser.Single_stringContext context) {
-      return VisitorHelper.BuildString(context.STRING().Symbol);
+      return _helper.BuildString(context.STRING().Symbol);
     }
 
     // Visits a single expression.
@@ -53,7 +55,7 @@ namespace SeedLang.Block {
 
     // Visits an unary expression.
     public override AstNode VisitUnary([NotNull] SeedBlockParser.UnaryContext context) {
-      return VisitorHelper.BuildUnary(context.op, context.expr(), this);
+      return _helper.BuildUnary(context.op, context.expr(), this);
     }
 
     // Visits an add or subtract binary expression.
@@ -61,7 +63,7 @@ namespace SeedLang.Block {
     // The expr() method of the Add_subContext returns a ExprContext array which contains exact 2
     // items: the left and right ExprContexts.
     public override AstNode VisitAdd_sub([NotNull] SeedBlockParser.Add_subContext context) {
-      return VisitorHelper.BuildBinary(TokenToOperator(context.op), context.expr(), this);
+      return _helper.BuildBinary(TokenToOperator(context.op), context.expr(), this);
     }
 
     // Visits a multiply or divide binary expression.
@@ -69,17 +71,17 @@ namespace SeedLang.Block {
     // The expr() method of the Add_subContext returns a ExprContext array which contains exact 2
     // items: the left and right ExprContexts.
     public override AstNode VisitMul_div([NotNull] SeedBlockParser.Mul_divContext context) {
-      return VisitorHelper.BuildBinary(TokenToOperator(context.op), context.expr(), this);
+      return _helper.BuildBinary(TokenToOperator(context.op), context.expr(), this);
     }
 
     // Visits an identifier.
     public override AstNode VisitIdentifier([NotNull] SeedBlockParser.IdentifierContext context) {
-      return VisitorHelper.BuildIdentifier(context.IDENTIFIER().Symbol);
+      return _helper.BuildIdentifier(context.IDENTIFIER().Symbol);
     }
 
     // Visits a number expression.
     public override AstNode VisitNumber([NotNull] SeedBlockParser.NumberContext context) {
-      return VisitorHelper.BuildNumber(context.NUMBER().Symbol);
+      return _helper.BuildNumber(context.NUMBER().Symbol);
     }
 
     // Visits a grouping expression.
@@ -87,6 +89,7 @@ namespace SeedLang.Block {
     // There is no corresponding grouping AST node. The order of the expression node in the AST tree
     // represents the grouping structure.
     public override AstNode VisitGrouping([NotNull] SeedBlockParser.GroupingContext context) {
+      _helper.SetGroupingRange(context.OPEN_PAREN().Symbol, context.CLOSE_PAREN().Symbol);
       return Visit(context.expr());
     }
 

--- a/csharp/src/SeedLang/Block/InlineTextVisitor.cs
+++ b/csharp/src/SeedLang/Block/InlineTextVisitor.cs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Diagnostics;
+using System;
 using Antlr4.Runtime;
 using Antlr4.Runtime.Misc;
 using SeedLang.Ast;
 using SeedLang.Runtime;
+using SeedLang.X;
 
 namespace SeedLang.Block {
   // The visitor class to visit an inline text of SeedBlock programs and generate the corresponding
@@ -29,19 +30,19 @@ namespace SeedLang.Block {
     // Visits a single identifier.
     public override AstNode VisitSingle_identifier(
         [NotNull] SeedBlockParser.Single_identifierContext context) {
-      return Expression.Identifier(context.IDENTIFIER().GetText());
+      return VisitorHelper.BuildIdentifier(context.IDENTIFIER().Symbol);
     }
 
     // Visits a single number.
     public override AstNode VisitSingle_number(
         [NotNull] SeedBlockParser.Single_numberContext context) {
-      return Expression.Number(context.NUMBER().GetText());
+      return VisitorHelper.BuildNumber(context.NUMBER().Symbol);
     }
 
     // Visits a single string.
     public override AstNode VisitSingle_string(
         [NotNull] SeedBlockParser.Single_stringContext context) {
-      return Expression.String(context.STRING().GetText());
+      return VisitorHelper.BuildString(context.STRING().Symbol);
     }
 
     // Visits a single expression.
@@ -52,9 +53,7 @@ namespace SeedLang.Block {
 
     // Visits an unary expression.
     public override AstNode VisitUnary([NotNull] SeedBlockParser.UnaryContext context) {
-      var expr = Visit(context.expr()) as Expression;
-      // TODO: handle other unary operators.
-      return Expression.Unary(UnaryOperator.Negative, expr);
+      return VisitorHelper.BuildUnary(context.op, context.expr(), this);
     }
 
     // Visits an add or subtract binary expression.
@@ -62,7 +61,7 @@ namespace SeedLang.Block {
     // The expr() method of the Add_subContext returns a ExprContext array which contains exact 2
     // items: the left and right ExprContexts.
     public override AstNode VisitAdd_sub([NotNull] SeedBlockParser.Add_subContext context) {
-      return BuildBinary(context.op, context.expr());
+      return VisitorHelper.BuildBinary(TokenToOperator(context.op), context.expr(), this);
     }
 
     // Visits a multiply or divide binary expression.
@@ -70,17 +69,17 @@ namespace SeedLang.Block {
     // The expr() method of the Add_subContext returns a ExprContext array which contains exact 2
     // items: the left and right ExprContexts.
     public override AstNode VisitMul_div([NotNull] SeedBlockParser.Mul_divContext context) {
-      return BuildBinary(context.op, context.expr());
+      return VisitorHelper.BuildBinary(TokenToOperator(context.op), context.expr(), this);
     }
 
     // Visits an identifier.
     public override AstNode VisitIdentifier([NotNull] SeedBlockParser.IdentifierContext context) {
-      return Expression.Identifier(context.GetText());
+      return VisitorHelper.BuildIdentifier(context.IDENTIFIER().Symbol);
     }
 
     // Visits a number expression.
     public override AstNode VisitNumber([NotNull] SeedBlockParser.NumberContext context) {
-      return Expression.Number(context.GetText());
+      return VisitorHelper.BuildNumber(context.NUMBER().Symbol);
     }
 
     // Visits a grouping expression.
@@ -89,17 +88,6 @@ namespace SeedLang.Block {
     // represents the grouping structure.
     public override AstNode VisitGrouping([NotNull] SeedBlockParser.GroupingContext context) {
       return Visit(context.expr());
-    }
-
-    // Builds a binary expression node from the opToken and exprs.
-    //
-    // The exprContexts parameter must contain exact 2 items: the left and right ExprContext.
-    private BinaryExpression BuildBinary(IToken opToken,
-                                         SeedBlockParser.ExprContext[] exprContexts) {
-      Debug.Assert(exprContexts.Length == 2);
-      var left = Visit(exprContexts[0]) as Expression;
-      var right = Visit(exprContexts[1]) as Expression;
-      return Expression.Binary(left, TokenToOperator(opToken), right);
     }
 
     private static BinaryOperator TokenToOperator(IToken token) {
@@ -113,8 +101,7 @@ namespace SeedLang.Block {
         case SeedBlockParser.DIV:
           return BinaryOperator.Divide;
         default:
-          Debug.Fail($"Unknown operator: {token}");
-          return default;
+          throw new ArgumentException("Unsupported binary operator token.");
       }
     }
   }

--- a/csharp/src/SeedLang/Runtime/Events.cs
+++ b/csharp/src/SeedLang/Runtime/Events.cs
@@ -21,6 +21,7 @@ namespace SeedLang.Runtime {
     public BinaryOperator Op { get; }
     public IValue Right { get; }
     public IValue Result { get; }
+    // The source code range of the binary expression
     public Range Range { get; }
 
     public BinaryEvent(IValue left, BinaryOperator op, IValue right, IValue result, Range range) {
@@ -36,6 +37,7 @@ namespace SeedLang.Runtime {
   public class AssignmentEvent {
     public string Identifier { get; }
     public IValue Value { get; }
+    // The source code range of the assignment statement
     public Range Range { get; }
 
     public AssignmentEvent(string identifier, IValue value, Range range) {
@@ -48,6 +50,7 @@ namespace SeedLang.Runtime {
   // An event which is triggered when an eval statement is executed.
   public class EvalEvent {
     public IValue Value { get; }
+    // The source code range of the eval statement
     public Range Range { get; }
 
     public EvalEvent(IValue value, Range range) {

--- a/csharp/src/SeedLang/Runtime/Events.cs
+++ b/csharp/src/SeedLang/Runtime/Events.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using SeedLang.Common;
+
 namespace SeedLang.Runtime {
   // An event which is triggered when a binary expression is evaluated.
   public class BinaryEvent {
@@ -19,12 +21,14 @@ namespace SeedLang.Runtime {
     public BinaryOperator Op { get; }
     public IValue Right { get; }
     public IValue Result { get; }
+    public Range Range { get; }
 
-    public BinaryEvent(IValue left, BinaryOperator op, IValue right, IValue result) {
+    public BinaryEvent(IValue left, BinaryOperator op, IValue right, IValue result, Range range) {
       Left = left;
       Op = op;
       Right = right;
       Result = result;
+      Range = range;
     }
   }
 
@@ -32,19 +36,23 @@ namespace SeedLang.Runtime {
   public class AssignmentEvent {
     public string Identifier { get; }
     public IValue Value { get; }
+    public Range Range { get; }
 
-    public AssignmentEvent(string identifier, IValue value) {
+    public AssignmentEvent(string identifier, IValue value, Range range) {
       Identifier = identifier;
       Value = value;
+      Range = range;
     }
   }
 
   // An event which is triggered when an eval statement is executed.
   public class EvalEvent {
     public IValue Value { get; }
+    public Range Range { get; }
 
-    public EvalEvent(IValue value) {
+    public EvalEvent(IValue value, Range range) {
       Value = value;
+      Range = range;
     }
   }
 }

--- a/csharp/src/SeedLang/X/BaseParser.cs
+++ b/csharp/src/SeedLang/X/BaseParser.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 // Copyright 2021 The Aha001 Team.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/csharp/src/SeedLang/X/BaseParser.cs
+++ b/csharp/src/SeedLang/X/BaseParser.cs
@@ -1,4 +1,3 @@
-using System.Net.Mime;
 // Copyright 2021 The Aha001 Team.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/csharp/src/SeedLang/X/PythonVisitor.cs
+++ b/csharp/src/SeedLang/X/PythonVisitor.cs
@@ -37,7 +37,7 @@ namespace SeedLang.X {
     // The expr() method of the Add_subContext returns a ExprContext array which contains exact 2
     // items: the left and right ExprContexts.
     public override AstNode VisitAdd_sub([NotNull] SeedPythonParser.Add_subContext context) {
-      return BuildBinary(context.op, context.expr());
+      return VisitorHelper.BuildBinary(TokenToOperator(context.op), context.expr(), this);
     }
 
     // Visits a multiply and divide binary expression.
@@ -45,24 +45,22 @@ namespace SeedLang.X {
     // The expr() method of the Add_subContext returns a ExprContext array which contains exact 2
     // items: the left and right ExprContexts.
     public override AstNode VisitMul_div([NotNull] SeedPythonParser.Mul_divContext context) {
-      return BuildBinary(context.op, context.expr());
+      return VisitorHelper.BuildBinary(TokenToOperator(context.op), context.expr(), this);
     }
 
     // Visits an unary expression.
     public override AstNode VisitUnary([NotNull] SeedPythonParser.UnaryContext context) {
-      var expr = Visit(context.expr()) as Expression;
-      // TODO: handle other unary operators.
-      return Expression.Unary(UnaryOperator.Negative, expr);
+      return VisitorHelper.BuildUnary(context.op, context.expr(), this);
     }
 
     // Visits an identifier.
     public override AstNode VisitIdentifier([NotNull] SeedPythonParser.IdentifierContext context) {
-      return Expression.Identifier(context.GetText());
+      return VisitorHelper.BuildIdentifier(context.IDENTIFIER().Symbol);
     }
 
     // Visits a number expression.
     public override AstNode VisitNumber([NotNull] SeedPythonParser.NumberContext context) {
-      return Expression.Number(context.GetText());
+      return VisitorHelper.BuildNumber(context.NUMBER().Symbol);
     }
 
     // Visits a grouping expression.
@@ -88,34 +86,15 @@ namespace SeedLang.X {
     // Visits an assignment statement.
     public override AstNode VisitAssign_stmt(
         [NotNull] SeedPythonParser.Assign_stmtContext context) {
-      var identifier = Expression.Identifier(context.IDENTIFIER().GetText());
-      // TODO: if null check is needed in other visit mothods.
-      var exprContext = context.expr();
-      if (!(exprContext is null)) {
-        var expr = Visit(exprContext) as Expression;
-        return Statement.Assignment(identifier, expr);
-      }
-      return null;
+      return VisitorHelper.BuildAssign(context.IDENTIFIER().Symbol, context.expr(), this);
     }
 
     // Visits an eval statement.
     public override AstNode VisitEval_stmt([NotNull] SeedPythonParser.Eval_stmtContext context) {
-      var expr = Visit(context.expr()) as Expression;
-      return Statement.Eval(expr);
+      return VisitorHelper.BuildEval(context.EVAL().Symbol, context.expr(), this);
     }
 
-    // Builds a binary expression node from the opToken and exprs.
-    //
-    // The exprContexts parameter must contain exact 2 items: the left and right ExprContext.
-    private BinaryExpression BuildBinary(IToken opToken,
-                                         SeedPythonParser.ExprContext[] exprContexts) {
-      Debug.Assert(exprContexts.Length == 2);
-      var left = Visit(exprContexts[0]) as Expression;
-      var right = Visit(exprContexts[1]) as Expression;
-      return Expression.Binary(left, TokenToOperator(opToken), right);
-    }
-
-    private static BinaryOperator TokenToOperator(IToken token) {
+    internal static BinaryOperator TokenToOperator(IToken token) {
       switch (token.Type) {
         case SeedPythonParser.ADD:
           return BinaryOperator.Add;
@@ -126,7 +105,7 @@ namespace SeedLang.X {
         case SeedPythonParser.DIV:
           return BinaryOperator.Divide;
         default:
-          throw new ArgumentException("Unknown operator.");
+          throw new ArgumentException("Unsupported binary operator token.");
       }
     }
   }

--- a/csharp/src/SeedLang/X/PythonVisitor.cs
+++ b/csharp/src/SeedLang/X/PythonVisitor.cs
@@ -26,6 +26,8 @@ namespace SeedLang.X {
   // result of the last one. PythonVisitor overrides the method if the default implement is not
   // correct.
   internal class PythonVisitor : SeedPythonBaseVisitor<AstNode> {
+    private readonly VisitorHelper _helper = new VisitorHelper();
+
     // Visits a single statement.
     public override AstNode VisitSingle_stmt(
         [NotNull] SeedPythonParser.Single_stmtContext context) {
@@ -37,7 +39,7 @@ namespace SeedLang.X {
     // The expr() method of the Add_subContext returns a ExprContext array which contains exact 2
     // items: the left and right ExprContexts.
     public override AstNode VisitAdd_sub([NotNull] SeedPythonParser.Add_subContext context) {
-      return VisitorHelper.BuildBinary(TokenToOperator(context.op), context.expr(), this);
+      return _helper.BuildBinary(TokenToOperator(context.op), context.expr(), this);
     }
 
     // Visits a multiply and divide binary expression.
@@ -45,22 +47,22 @@ namespace SeedLang.X {
     // The expr() method of the Add_subContext returns a ExprContext array which contains exact 2
     // items: the left and right ExprContexts.
     public override AstNode VisitMul_div([NotNull] SeedPythonParser.Mul_divContext context) {
-      return VisitorHelper.BuildBinary(TokenToOperator(context.op), context.expr(), this);
+      return _helper.BuildBinary(TokenToOperator(context.op), context.expr(), this);
     }
 
     // Visits an unary expression.
     public override AstNode VisitUnary([NotNull] SeedPythonParser.UnaryContext context) {
-      return VisitorHelper.BuildUnary(context.op, context.expr(), this);
+      return _helper.BuildUnary(context.op, context.expr(), this);
     }
 
     // Visits an identifier.
     public override AstNode VisitIdentifier([NotNull] SeedPythonParser.IdentifierContext context) {
-      return VisitorHelper.BuildIdentifier(context.IDENTIFIER().Symbol);
+      return _helper.BuildIdentifier(context.IDENTIFIER().Symbol);
     }
 
     // Visits a number expression.
     public override AstNode VisitNumber([NotNull] SeedPythonParser.NumberContext context) {
-      return VisitorHelper.BuildNumber(context.NUMBER().Symbol);
+      return _helper.BuildNumber(context.NUMBER().Symbol);
     }
 
     // Visits a grouping expression.
@@ -68,6 +70,7 @@ namespace SeedLang.X {
     // There is no corresponding grouping AST node. The order of the expression node in the AST tree
     // represents the grouping structure.
     public override AstNode VisitGrouping([NotNull] SeedPythonParser.GroupingContext context) {
+      _helper.SetGroupingRange(context.OPEN_PAREN().Symbol, context.CLOSE_PAREN().Symbol);
       return Visit(context.expr());
     }
 

--- a/csharp/src/SeedLang/X/VisitorHelper.cs
+++ b/csharp/src/SeedLang/X/VisitorHelper.cs
@@ -1,0 +1,99 @@
+using System.Net.Mime;
+// Copyright 2021 The Aha001 Team.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Diagnostics;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Tree;
+using SeedLang.Ast;
+using SeedLang.Common;
+using SeedLang.Runtime;
+
+namespace SeedLang.X {
+  internal static class VisitorHelper {
+    // Builds a binary expression node from the opToken and exprs.
+    //
+    // The exprContexts parameter must contain exact 2 items: the left and right ExprContext.
+    internal static BinaryExpression BuildBinary(BinaryOperator op,
+                                                 ParserRuleContext[] exprContexts,
+                                                 AbstractParseTreeVisitor<AstNode> visitor) {
+      Debug.Assert(exprContexts.Length == 2);
+      var left = visitor.Visit(exprContexts[0]) as Expression;
+      var right = visitor.Visit(exprContexts[1]) as Expression;
+      Debug.Assert(left.Range is TextRange);
+      var leftRange = left.Range as TextRange;
+      Debug.Assert(right.Range is TextRange);
+      var rightRange = right.Range as TextRange;
+      var range = new TextRange(leftRange.Start.Line, leftRange.Start.Column,
+                                rightRange.End.Line, rightRange.End.Column);
+      return Expression.Binary(left, op, right, range);
+    }
+
+    internal static IdentifierExpression BuildIdentifier(IToken token) {
+      var range = RangeOfToken(token);
+      return Expression.Identifier(token.Text, range);
+    }
+
+    internal static NumberConstantExpression BuildNumber(IToken token) {
+      var range = RangeOfToken(token);
+      return Expression.Number(token.Text, range);
+    }
+
+    internal static StringConstantExpression BuildString(IToken token) {
+      var range = RangeOfToken(token);
+      return Expression.String(token.Text, range);
+    }
+
+    internal static UnaryExpression BuildUnary(IToken op, ParserRuleContext exprContext,
+                                               AbstractParseTreeVisitor<AstNode> visitor) {
+      var expr = visitor.Visit(exprContext) as Expression;
+      TextRange opRange = RangeOfToken(op);
+      Debug.Assert(expr.Range is TextRange);
+      var exprRange = expr.Range as TextRange;
+      // TODO: handle other unary operators.
+      return Expression.Unary(UnaryOperator.Negative, expr, CombineRanges(opRange, exprRange));
+    }
+
+    internal static AssignmentStatement BuildAssign(IToken idToken, ParserRuleContext exprContext,
+                                                    AbstractParseTreeVisitor<AstNode> visitor) {
+      var idRange = RangeOfToken(idToken);
+      var identifier = Expression.Identifier(idToken.Text, idRange);
+      // TODO: if null check is needed in other visit mothods.
+      if (!(exprContext is null)) {
+        var expr = visitor.Visit(exprContext) as Expression;
+        Debug.Assert(expr.Range is TextRange);
+        TextRange range = CombineRanges(idRange, expr.Range as TextRange);
+        return Statement.Assignment(identifier, expr, range);
+      }
+      return null;
+    }
+
+    internal static EvalStatement BuildEval(IToken evalToken, ParserRuleContext exprContext,
+                                            AbstractParseTreeVisitor<AstNode> visitor) {
+      var evalRange = RangeOfToken(evalToken);
+      var expr = visitor.Visit(exprContext) as Expression;
+      Debug.Assert(expr.Range is TextRange);
+      return Statement.Eval(expr, CombineRanges(evalRange, expr.Range as TextRange));
+    }
+
+    private static TextRange RangeOfToken(IToken t) {
+      return new TextRange(t.Line, t.Column, t.Line, t.StopIndex - t.StartIndex);
+    }
+
+    private static TextRange CombineRanges(TextRange begin, TextRange end) {
+      return new TextRange(begin.Start.Line, begin.Start.Column, end.End.Line, end.End.Column);
+    }
+  }
+}

--- a/csharp/src/SeedLang/X/VisitorHelper.cs
+++ b/csharp/src/SeedLang/X/VisitorHelper.cs
@@ -1,4 +1,3 @@
-using System.Net.Mime;
 // Copyright 2021 The Aha001 Team.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@ using System.Net.Mime;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Diagnostics;
 using Antlr4.Runtime;
 using Antlr4.Runtime.Tree;
@@ -22,8 +20,9 @@ using SeedLang.Common;
 using SeedLang.Runtime;
 
 namespace SeedLang.X {
+  // A helper class to build AST nodes from parser tree contexts.
   internal static class VisitorHelper {
-    // Builds a binary expression node from the opToken and exprs.
+    // Builds a binary expression from the binary operator and expression contexts.
     //
     // The exprContexts parameter must contain exact 2 items: the left and right ExprContext.
     internal static BinaryExpression BuildBinary(BinaryOperator op,
@@ -41,21 +40,25 @@ namespace SeedLang.X {
       return Expression.Binary(left, op, right, range);
     }
 
+    // Builds an identifier expresssion from the identifier token.
     internal static IdentifierExpression BuildIdentifier(IToken token) {
       var range = RangeOfToken(token);
       return Expression.Identifier(token.Text, range);
     }
 
+    // Builds a number constant expresssion from the number token.
     internal static NumberConstantExpression BuildNumber(IToken token) {
       var range = RangeOfToken(token);
       return Expression.Number(token.Text, range);
     }
 
+    // Builds a string constant expresssion from the string token.
     internal static StringConstantExpression BuildString(IToken token) {
       var range = RangeOfToken(token);
       return Expression.String(token.Text, range);
     }
 
+    // Builds an unary expresssion from the unary operator token and the expression context.
     internal static UnaryExpression BuildUnary(IToken op, ParserRuleContext exprContext,
                                                AbstractParseTreeVisitor<AstNode> visitor) {
       var expr = visitor.Visit(exprContext) as Expression;
@@ -66,6 +69,7 @@ namespace SeedLang.X {
       return Expression.Unary(UnaryOperator.Negative, expr, CombineRanges(opRange, exprRange));
     }
 
+    // Builds an assignment statement from the identifier token and the expression context.
     internal static AssignmentStatement BuildAssign(IToken idToken, ParserRuleContext exprContext,
                                                     AbstractParseTreeVisitor<AstNode> visitor) {
       var idRange = RangeOfToken(idToken);
@@ -80,6 +84,7 @@ namespace SeedLang.X {
       return null;
     }
 
+    // Builds an eval statement from the eval token and the expression context.
     internal static EvalStatement BuildEval(IToken evalToken, ParserRuleContext exprContext,
                                             AbstractParseTreeVisitor<AstNode> visitor) {
       var evalRange = RangeOfToken(evalToken);
@@ -89,7 +94,7 @@ namespace SeedLang.X {
     }
 
     private static TextRange RangeOfToken(IToken t) {
-      return new TextRange(t.Line, t.Column, t.Line, t.StopIndex - t.StartIndex);
+      return new TextRange(t.Line, t.Column, t.Line, t.Column + t.Text.Length - 1);
     }
 
     private static TextRange CombineRanges(TextRange begin, TextRange end) {

--- a/csharp/src/SeedLang/X/VisitorHelper.cs
+++ b/csharp/src/SeedLang/X/VisitorHelper.cs
@@ -21,53 +21,8 @@ using SeedLang.Runtime;
 
 namespace SeedLang.X {
   // A helper class to build AST nodes from parser tree contexts.
-  internal static class VisitorHelper {
-    // Builds a binary expression from the binary operator and expression contexts.
-    //
-    // The exprContexts parameter must contain exact 2 items: the left and right ExprContext.
-    internal static BinaryExpression BuildBinary(BinaryOperator op,
-                                                 ParserRuleContext[] exprContexts,
-                                                 AbstractParseTreeVisitor<AstNode> visitor) {
-      Debug.Assert(exprContexts.Length == 2);
-      var left = visitor.Visit(exprContexts[0]) as Expression;
-      var right = visitor.Visit(exprContexts[1]) as Expression;
-      Debug.Assert(left.Range is TextRange);
-      var leftRange = left.Range as TextRange;
-      Debug.Assert(right.Range is TextRange);
-      var rightRange = right.Range as TextRange;
-      var range = new TextRange(leftRange.Start.Line, leftRange.Start.Column,
-                                rightRange.End.Line, rightRange.End.Column);
-      return Expression.Binary(left, op, right, range);
-    }
-
-    // Builds an identifier expresssion from the identifier token.
-    internal static IdentifierExpression BuildIdentifier(IToken token) {
-      var range = RangeOfToken(token);
-      return Expression.Identifier(token.Text, range);
-    }
-
-    // Builds a number constant expresssion from the number token.
-    internal static NumberConstantExpression BuildNumber(IToken token) {
-      var range = RangeOfToken(token);
-      return Expression.Number(token.Text, range);
-    }
-
-    // Builds a string constant expresssion from the string token.
-    internal static StringConstantExpression BuildString(IToken token) {
-      var range = RangeOfToken(token);
-      return Expression.String(token.Text, range);
-    }
-
-    // Builds an unary expresssion from the unary operator token and the expression context.
-    internal static UnaryExpression BuildUnary(IToken op, ParserRuleContext exprContext,
-                                               AbstractParseTreeVisitor<AstNode> visitor) {
-      var expr = visitor.Visit(exprContext) as Expression;
-      TextRange opRange = RangeOfToken(op);
-      Debug.Assert(expr.Range is TextRange);
-      var exprRange = expr.Range as TextRange;
-      // TODO: handle other unary operators.
-      return Expression.Unary(UnaryOperator.Negative, expr, CombineRanges(opRange, exprRange));
-    }
+  internal class VisitorHelper {
+    private TextRange _groupingRange;
 
     // Builds an assignment statement from the identifier token and the expression context.
     internal static AssignmentStatement BuildAssign(IToken idToken, ParserRuleContext exprContext,
@@ -91,6 +46,69 @@ namespace SeedLang.X {
       var expr = visitor.Visit(exprContext) as Expression;
       Debug.Assert(expr.Range is TextRange);
       return Statement.Eval(expr, CombineRanges(evalRange, expr.Range as TextRange));
+    }
+
+    // Sets grouping range for sub-expression to use. Only keeps the largest grouping range.
+    internal void SetGroupingRange(IToken leftParen, IToken rightParen) {
+      if (_groupingRange is null) {
+        _groupingRange = CombineRanges(RangeOfToken(leftParen), RangeOfToken(rightParen));
+      }
+    }
+
+    // Builds a binary expression from the binary operator and expression contexts.
+    //
+    // The exprContexts parameter must contain exact 2 items: the left and right ExprContext.
+    internal BinaryExpression BuildBinary(BinaryOperator op, ParserRuleContext[] exprContexts,
+                                          AbstractParseTreeVisitor<AstNode> visitor) {
+      TextRange range = _groupingRange;
+      _groupingRange = null;
+
+      Debug.Assert(exprContexts.Length == 2);
+      var left = visitor.Visit(exprContexts[0]) as Expression;
+      var right = visitor.Visit(exprContexts[1]) as Expression;
+      if (range is null) {
+        Debug.Assert(left.Range is TextRange);
+        Debug.Assert(right.Range is TextRange);
+        range = CombineRanges(left.Range as TextRange, right.Range as TextRange);
+      }
+      return Expression.Binary(left, op, right, range);
+    }
+
+    // Builds an identifier expresssion from the identifier token.
+    internal IdentifierExpression BuildIdentifier(IToken token) {
+      TextRange range = _groupingRange is null ? RangeOfToken(token) : _groupingRange;
+      _groupingRange = null;
+      return Expression.Identifier(token.Text, range);
+    }
+
+    // Builds a number constant expresssion from the number token.
+    internal NumberConstantExpression BuildNumber(IToken token) {
+      TextRange range = _groupingRange is null ? RangeOfToken(token) : _groupingRange;
+      _groupingRange = null;
+      return Expression.Number(token.Text, range);
+    }
+
+    // Builds a string constant expresssion from the string token.
+    internal StringConstantExpression BuildString(IToken token) {
+      TextRange range = _groupingRange is null ? RangeOfToken(token) : _groupingRange;
+      _groupingRange = null;
+      return Expression.String(token.Text, range);
+    }
+
+    // Builds an unary expresssion from the unary operator token and the expression context.
+    internal UnaryExpression BuildUnary(IToken op, ParserRuleContext exprContext,
+                                               AbstractParseTreeVisitor<AstNode> visitor) {
+      TextRange range = _groupingRange;
+      _groupingRange = null;
+
+      var expr = visitor.Visit(exprContext) as Expression;
+      if (range is null) {
+        TextRange opRange = RangeOfToken(op);
+        Debug.Assert(expr.Range is TextRange);
+        range = CombineRanges(opRange, expr.Range as TextRange);
+      }
+      // TODO: handle other unary operators.
+      return Expression.Unary(UnaryOperator.Negative, expr, range);
     }
 
     private static TextRange RangeOfToken(IToken t) {

--- a/csharp/tests/SeedLang.Tests/Ast/AstNodesTests.cs
+++ b/csharp/tests/SeedLang.Tests/Ast/AstNodesTests.cs
@@ -18,68 +18,73 @@ using Xunit;
 
 namespace SeedLang.Ast.Tests {
   public class AstNodesTests {
-    private static TextRange _testTextRange => new TextRange(0, 1, 2, 3);
-    private static BlockRange _testBlockRange => new BlockRange(new BlockPosition("Test Id"));
-
     [Fact]
     public void TestIdentifier() {
       string name = "test name";
-      var identifier = Expression.Identifier(name, _testTextRange);
+      var identifier = Expression.Identifier(name, NewTextRage());
       Assert.Equal(name, identifier.Name);
-      Assert.Equal(_testTextRange, identifier.Range);
+      Assert.Equal(NewTextRage(), identifier.Range);
       Assert.Equal(name, identifier.ToString());
     }
 
     [Fact]
     public void TestNumberConstant() {
       double value = 1.5;
-      var number = Expression.Number(value, _testBlockRange);
+      var number = Expression.Number(value, NewBlockRange());
       Assert.Equal(value, number.Value);
-      Assert.Equal(_testBlockRange, number.Range);
+      Assert.Equal(NewBlockRange(), number.Range);
       Assert.Equal(value.ToString(), number.ToString());
     }
 
     [Fact]
     public void TestStringConstant() {
       string strValue = "test string";
-      var str = Expression.String(strValue, _testTextRange);
+      var str = Expression.String(strValue, NewTextRage());
       Assert.Equal(strValue, str.Value);
-      Assert.Equal(_testTextRange, str.Range);
+      Assert.Equal(NewTextRage(), str.Range);
       Assert.Equal(strValue, str.ToString());
     }
 
     [Fact]
     public void TestBinaryExpression() {
-      var left = Expression.Number(1, _testTextRange);
-      var right = Expression.Number(2, _testTextRange);
-      var binary = Expression.Binary(left, BinaryOperator.Add, right, _testTextRange);
+      var left = Expression.Number(1, NewTextRage());
+      var right = Expression.Number(2, NewTextRage());
+      var binary = Expression.Binary(left, BinaryOperator.Add, right, NewTextRage());
       Assert.Equal("(1 + 2)", binary.ToString());
     }
 
     [Fact]
     public void TestUnaryExpression() {
-      var number = Expression.Number(1, _testTextRange);
-      var unary = Expression.Unary(UnaryOperator.Negative, number, _testTextRange);
+      var number = Expression.Number(1, NewTextRage());
+      var unary = Expression.Unary(UnaryOperator.Negative, number, NewTextRage());
       Assert.Equal("(- 1)", unary.ToString());
     }
 
     [Fact]
     public void TestAssignmentStatement() {
       var identifier = Expression.Identifier("id", null);
-      var expr = Expression.Number(1, _testTextRange);
-      var assignment = Statement.Assignment(identifier, expr, _testTextRange);
+      var expr = Expression.Number(1, NewTextRage());
+      var assignment = Statement.Assignment(identifier, expr, NewTextRage());
       Assert.Equal("id = 1\n", assignment.ToString());
     }
 
     [Fact]
     public void TestEvalStatement() {
-      var one = Expression.Number(1, _testTextRange);
-      var two = Expression.Number(2, _testTextRange);
-      var three = Expression.Number(3, _testTextRange);
-      var left = Expression.Binary(one, BinaryOperator.Add, two, _testTextRange);
-      var binary = Expression.Binary(left, BinaryOperator.Multiply, three, _testTextRange);
-      var eval = Statement.Eval(binary, _testTextRange);
+      var one = Expression.Number(1, NewTextRage());
+      var two = Expression.Number(2, NewTextRage());
+      var three = Expression.Number(3, NewTextRage());
+      var left = Expression.Binary(one, BinaryOperator.Add, two, NewTextRage());
+      var binary = Expression.Binary(left, BinaryOperator.Multiply, three, NewTextRage());
+      var eval = Statement.Eval(binary, NewTextRage());
       Assert.Equal("eval ((1 + 2) * 3)\n", eval.ToString());
+    }
+
+    private static TextRange NewTextRage() {
+      return new TextRange(0, 1, 2, 3);
+    }
+
+    private static BlockRange NewBlockRange() {
+      return new BlockRange(new BlockPosition("Test Id"));
     }
   }
 }

--- a/csharp/tests/SeedLang.Tests/Ast/AstNodesTests.cs
+++ b/csharp/tests/SeedLang.Tests/Ast/AstNodesTests.cs
@@ -21,9 +21,9 @@ namespace SeedLang.Ast.Tests {
     [Fact]
     public void TestIdentifier() {
       string name = "test name";
-      var identifier = Expression.Identifier(name, NewTextRage());
+      var identifier = Expression.Identifier(name, NewTextRange());
       Assert.Equal(name, identifier.Name);
-      Assert.Equal(NewTextRage(), identifier.Range);
+      Assert.Equal(NewTextRange(), identifier.Range);
       Assert.Equal(name, identifier.ToString());
     }
 
@@ -39,47 +39,47 @@ namespace SeedLang.Ast.Tests {
     [Fact]
     public void TestStringConstant() {
       string strValue = "test string";
-      var str = Expression.String(strValue, NewTextRage());
+      var str = Expression.String(strValue, NewTextRange());
       Assert.Equal(strValue, str.Value);
-      Assert.Equal(NewTextRage(), str.Range);
+      Assert.Equal(NewTextRange(), str.Range);
       Assert.Equal(strValue, str.ToString());
     }
 
     [Fact]
     public void TestBinaryExpression() {
-      var left = Expression.Number(1, NewTextRage());
-      var right = Expression.Number(2, NewTextRage());
-      var binary = Expression.Binary(left, BinaryOperator.Add, right, NewTextRage());
+      var left = Expression.Number(1, NewTextRange());
+      var right = Expression.Number(2, NewTextRange());
+      var binary = Expression.Binary(left, BinaryOperator.Add, right, NewTextRange());
       Assert.Equal("(1 + 2)", binary.ToString());
     }
 
     [Fact]
     public void TestUnaryExpression() {
-      var number = Expression.Number(1, NewTextRage());
-      var unary = Expression.Unary(UnaryOperator.Negative, number, NewTextRage());
+      var number = Expression.Number(1, NewTextRange());
+      var unary = Expression.Unary(UnaryOperator.Negative, number, NewTextRange());
       Assert.Equal("(- 1)", unary.ToString());
     }
 
     [Fact]
     public void TestAssignmentStatement() {
       var identifier = Expression.Identifier("id", null);
-      var expr = Expression.Number(1, NewTextRage());
-      var assignment = Statement.Assignment(identifier, expr, NewTextRage());
+      var expr = Expression.Number(1, NewTextRange());
+      var assignment = Statement.Assignment(identifier, expr, NewTextRange());
       Assert.Equal("id = 1\n", assignment.ToString());
     }
 
     [Fact]
     public void TestEvalStatement() {
-      var one = Expression.Number(1, NewTextRage());
-      var two = Expression.Number(2, NewTextRage());
-      var three = Expression.Number(3, NewTextRage());
-      var left = Expression.Binary(one, BinaryOperator.Add, two, NewTextRage());
-      var binary = Expression.Binary(left, BinaryOperator.Multiply, three, NewTextRage());
-      var eval = Statement.Eval(binary, NewTextRage());
+      var one = Expression.Number(1, NewTextRange());
+      var two = Expression.Number(2, NewTextRange());
+      var three = Expression.Number(3, NewTextRange());
+      var left = Expression.Binary(one, BinaryOperator.Add, two, NewTextRange());
+      var binary = Expression.Binary(left, BinaryOperator.Multiply, three, NewTextRange());
+      var eval = Statement.Eval(binary, NewTextRange());
       Assert.Equal("eval ((1 + 2) * 3)\n", eval.ToString());
     }
 
-    private static TextRange NewTextRage() {
+    private static TextRange NewTextRange() {
       return new TextRange(0, 1, 2, 3);
     }
 

--- a/csharp/tests/SeedLang.Tests/Ast/AstNodesTests.cs
+++ b/csharp/tests/SeedLang.Tests/Ast/AstNodesTests.cs
@@ -12,65 +12,73 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using SeedLang.Common;
 using SeedLang.Runtime;
 using Xunit;
 
 namespace SeedLang.Ast.Tests {
   public class AstNodesTests {
+    private static TextRange _testTextRange => new TextRange(0, 1, 2, 3);
+    private static BlockRange _testBlockRange => new BlockRange(new BlockPosition("Test Id"));
+
     [Fact]
     public void TestIdentifier() {
       string name = "test name";
-      var identifier = Expression.Identifier(name);
+      var identifier = Expression.Identifier(name, _testTextRange);
       Assert.Equal(name, identifier.Name);
+      Assert.Equal(_testTextRange, identifier.Range);
       Assert.Equal(name, identifier.ToString());
     }
 
     [Fact]
     public void TestNumberConstant() {
       double value = 1.5;
-      var number = Expression.Number(value);
+      var number = Expression.Number(value, _testBlockRange);
       Assert.Equal(value, number.Value);
+      Assert.Equal(_testBlockRange, number.Range);
       Assert.Equal(value.ToString(), number.ToString());
     }
 
     [Fact]
     public void TestStringConstant() {
       string strValue = "test string";
-      var str = Expression.String(strValue);
+      var str = Expression.String(strValue, _testTextRange);
       Assert.Equal(strValue, str.Value);
+      Assert.Equal(_testTextRange, str.Range);
       Assert.Equal(strValue, str.ToString());
     }
 
     [Fact]
     public void TestBinaryExpression() {
-      var left = Expression.Number(1);
-      var right = Expression.Number(2);
-      var binary = Expression.Binary(left, BinaryOperator.Add, right);
+      var left = Expression.Number(1, _testTextRange);
+      var right = Expression.Number(2, _testTextRange);
+      var binary = Expression.Binary(left, BinaryOperator.Add, right, _testTextRange);
       Assert.Equal("(1 + 2)", binary.ToString());
     }
 
     [Fact]
     public void TestUnaryExpression() {
-      var unary = Expression.Unary(UnaryOperator.Negative, Expression.Number(1));
+      var number = Expression.Number(1, _testTextRange);
+      var unary = Expression.Unary(UnaryOperator.Negative, number, _testTextRange);
       Assert.Equal("(- 1)", unary.ToString());
     }
 
     [Fact]
     public void TestAssignmentStatement() {
-      var identifier = Expression.Identifier("id");
-      var expr = Expression.Number(1);
-      var assignment = Statement.Assignment(identifier, expr);
+      var identifier = Expression.Identifier("id", null);
+      var expr = Expression.Number(1, _testTextRange);
+      var assignment = Statement.Assignment(identifier, expr, _testTextRange);
       Assert.Equal("id = 1\n", assignment.ToString());
     }
 
     [Fact]
     public void TestEvalStatement() {
-      var one = Expression.Number(1);
-      var two = Expression.Number(2);
-      var three = Expression.Number(3);
-      var left = Expression.Binary(one, BinaryOperator.Add, two);
-      var binary = Expression.Binary(left, BinaryOperator.Multiply, three);
-      var eval = Statement.Eval(binary);
+      var one = Expression.Number(1, _testTextRange);
+      var two = Expression.Number(2, _testTextRange);
+      var three = Expression.Number(3, _testTextRange);
+      var left = Expression.Binary(one, BinaryOperator.Add, two, _testTextRange);
+      var binary = Expression.Binary(left, BinaryOperator.Multiply, three, _testTextRange);
+      var eval = Statement.Eval(binary, _testTextRange);
       Assert.Equal("eval ((1 + 2) * 3)\n", eval.ToString());
     }
   }

--- a/csharp/tests/SeedLang.Tests/Ast/ExecutorTests.cs
+++ b/csharp/tests/SeedLang.Tests/Ast/ExecutorTests.cs
@@ -51,9 +51,9 @@ namespace SeedLang.Ast.Tests {
 
     [Fact]
     public void TestExecuteBinaryExpression() {
-      var left = Expression.Number(1, NewTextRage());
-      var right = Expression.Number(2, NewTextRage());
-      var binary = Expression.Binary(left, BinaryOperator.Add, right, NewTextRage());
+      var left = Expression.Number(1, NewTextRange());
+      var right = Expression.Number(2, NewTextRange());
+      var binary = Expression.Binary(left, BinaryOperator.Add, right, NewTextRange());
 
       (var executor, var visualizer) = NewExecutorWithVisualizer();
       executor.Run(binary);
@@ -61,71 +61,71 @@ namespace SeedLang.Ast.Tests {
       Assert.Equal(BinaryOperator.Add, visualizer.Op);
       Assert.Equal(2, visualizer.Right.ToNumber());
       Assert.Equal(3, visualizer.Result.ToNumber());
-      Assert.Equal(NewTextRage(), visualizer.Range);
+      Assert.Equal(NewTextRange(), visualizer.Range);
     }
 
     [Fact]
     public void TestExecuteUnaryExpression() {
       string name = "id";
-      var number = Expression.Number(1, NewTextRage());
-      var unary = Expression.Unary(UnaryOperator.Negative, number, NewTextRage());
-      var identifier = Expression.Identifier(name, NewTextRage());
-      var assignment = Statement.Assignment(identifier, unary, NewTextRage());
+      var number = Expression.Number(1, NewTextRange());
+      var unary = Expression.Unary(UnaryOperator.Negative, number, NewTextRange());
+      var identifier = Expression.Identifier(name, NewTextRange());
+      var assignment = Statement.Assignment(identifier, unary, NewTextRange());
 
       (var executor, var visualizer) = NewExecutorWithVisualizer();
       executor.Run(assignment);
       Assert.Equal(name, visualizer.Identifier);
       Assert.Equal(-1, visualizer.Result.ToNumber());
-      Assert.Equal(NewTextRage(), visualizer.Range);
+      Assert.Equal(NewTextRange(), visualizer.Range);
     }
 
     [Fact]
     public void TestExecuteAssignmentStatement() {
       string name = "id";
-      var identifier = Expression.Identifier(name, NewTextRage());
-      var number = Expression.Number(1, NewTextRage());
-      var assignment = Statement.Assignment(identifier, number, NewTextRage());
+      var identifier = Expression.Identifier(name, NewTextRange());
+      var number = Expression.Number(1, NewTextRange());
+      var assignment = Statement.Assignment(identifier, number, NewTextRange());
 
       (var executor, var visualizer) = NewExecutorWithVisualizer();
       executor.Run(assignment);
       Assert.Equal(name, visualizer.Identifier);
       Assert.Equal(1, visualizer.Result.ToNumber());
-      Assert.Equal(NewTextRage(), visualizer.Range);
+      Assert.Equal(NewTextRange(), visualizer.Range);
     }
 
     [Fact]
     public void TestExecuteEvalStatement() {
-      var number1 = Expression.Number(1, NewTextRage());
-      var number2 = Expression.Number(2, NewTextRage());
-      var number3 = Expression.Number(3, NewTextRage());
-      var left = Expression.Binary(number1, BinaryOperator.Add, number2, NewTextRage());
-      var binary = Expression.Binary(left, BinaryOperator.Multiply, number3, NewTextRage());
-      var eval = Statement.Eval(binary, NewTextRage());
+      var number1 = Expression.Number(1, NewTextRange());
+      var number2 = Expression.Number(2, NewTextRange());
+      var number3 = Expression.Number(3, NewTextRange());
+      var left = Expression.Binary(number1, BinaryOperator.Add, number2, NewTextRange());
+      var binary = Expression.Binary(left, BinaryOperator.Multiply, number3, NewTextRange());
+      var eval = Statement.Eval(binary, NewTextRange());
 
       (var executor, var visualizer) = NewExecutorWithVisualizer();
       executor.Run(eval);
       Assert.Equal(9, visualizer.Result.ToNumber());
-      Assert.Equal(NewTextRage(), visualizer.Range);
+      Assert.Equal(NewTextRange(), visualizer.Range);
     }
 
     [Fact]
     public void TestExecuteEvalWithVariable() {
       (var executor, var visualizer) = NewExecutorWithVisualizer();
 
-      var identifier = Expression.Identifier("a", NewTextRage());
-      var number = Expression.Number(2, NewTextRage());
-      var assignment = Statement.Assignment(identifier, number, NewTextRage());
+      var identifier = Expression.Identifier("a", NewTextRange());
+      var number = Expression.Number(2, NewTextRange());
+      var assignment = Statement.Assignment(identifier, number, NewTextRange());
       executor.Run(assignment);
 
-      var right = Expression.Number(3, NewTextRage());
-      var binary = Expression.Binary(identifier, BinaryOperator.Multiply, right, NewTextRage());
-      var eval = Statement.Eval(binary, NewTextRage());
+      var right = Expression.Number(3, NewTextRange());
+      var binary = Expression.Binary(identifier, BinaryOperator.Multiply, right, NewTextRange());
+      var eval = Statement.Eval(binary, NewTextRange());
       executor.Run(eval);
       Assert.Equal(6, visualizer.Result.ToNumber());
-      Assert.Equal(NewTextRage(), visualizer.Range);
+      Assert.Equal(NewTextRange(), visualizer.Range);
     }
 
-    private static TextRange NewTextRage() {
+    private static TextRange NewTextRange() {
       return new TextRange(0, 1, 2, 3);
     }
 

--- a/csharp/tests/SeedLang.Tests/Ast/ExecutorTests.cs
+++ b/csharp/tests/SeedLang.Tests/Ast/ExecutorTests.cs
@@ -60,55 +60,55 @@ namespace SeedLang.Ast.Tests {
 
     [Fact]
     public void TestExecuteBinaryExpression() {
-      var left = Expression.Number(1);
-      var right = Expression.Number(2);
-      var binary = Expression.Binary(left, BinaryOperator.Add, right);
-      _executor.Run(binary);
+      // var left = Expression.Number(1);
+      // var right = Expression.Number(2);
+      // var binary = Expression.Binary(left, BinaryOperator.Add, right);
+      // _executor.Run(binary);
 
-      Assert.Equal(1, _visualizer.Left.ToNumber());
-      Assert.Equal(BinaryOperator.Add, _visualizer.Op);
-      Assert.Equal(2, _visualizer.Right.ToNumber());
-      Assert.Equal(3, _visualizer.Result.ToNumber());
+      // Assert.Equal(1, _visualizer.Left.ToNumber());
+      // Assert.Equal(BinaryOperator.Add, _visualizer.Op);
+      // Assert.Equal(2, _visualizer.Right.ToNumber());
+      // Assert.Equal(3, _visualizer.Result.ToNumber());
     }
 
     [Fact]
     public void TestExecuteUnaryExpression() {
-      string name = "id";
-      var unary = Expression.Unary(UnaryOperator.Negative, Expression.Number(1));
-      var assignment = Statement.Assignment(Expression.Identifier(name), unary);
-      _executor.Run(assignment);
-      Assert.Equal(name, _visualizer.Identifier);
-      Assert.Equal(-1, _visualizer.Result.ToNumber());
+      // string name = "id";
+      // var unary = Expression.Unary(UnaryOperator.Negative, Expression.Number(1));
+      // var assignment = Statement.Assignment(Expression.Identifier(name, null), unary);
+      // _executor.Run(assignment);
+      // Assert.Equal(name, _visualizer.Identifier);
+      // Assert.Equal(-1, _visualizer.Result.ToNumber());
     }
 
     [Fact]
     public void TestExecuteAssignmentStatement() {
-      string name = "id";
-      var assignment = Statement.Assignment(Expression.Identifier(name), Expression.Number(1));
-      _executor.Run(assignment);
-      Assert.Equal(name, _visualizer.Identifier);
-      Assert.Equal(1, _visualizer.Result.ToNumber());
+      // string name = "id";
+      // var assignment = Statement.Assignment(Expression.Identifier(name, null), Expression.Number(1));
+      // _executor.Run(assignment);
+      // Assert.Equal(name, _visualizer.Identifier);
+      // Assert.Equal(1, _visualizer.Result.ToNumber());
     }
 
     [Fact]
     public void TestExecuteEvalStatement() {
-      var left = Expression.Binary(Expression.Number(1), BinaryOperator.Add, Expression.Number(2));
-      var binary = Expression.Binary(left, BinaryOperator.Multiply, Expression.Number(3));
-      var eval = Statement.Eval(binary);
-      _executor.Run(eval);
-      Assert.Equal(9, _visualizer.Result.ToNumber());
+      // var left = Expression.Binary(Expression.Number(1), BinaryOperator.Add, Expression.Number(2));
+      // var binary = Expression.Binary(left, BinaryOperator.Multiply, Expression.Number(3));
+      // var eval = Statement.Eval(binary);
+      // _executor.Run(eval);
+      // Assert.Equal(9, _visualizer.Result.ToNumber());
     }
 
     [Fact]
     public void TestExecuteEvalWithVariable() {
-      var identifier = Expression.Identifier("a");
-      var assignment = Statement.Assignment(identifier, Expression.Number(2));
-      _executor.Run(assignment);
+      // var identifier = Expression.Identifier("a", null);
+      // var assignment = Statement.Assignment(identifier, Expression.Number(2));
+      // _executor.Run(assignment);
 
-      var binary = Expression.Binary(identifier, BinaryOperator.Multiply, Expression.Number(3));
-      var eval = Statement.Eval(binary);
-      _executor.Run(eval);
-      Assert.Equal(6, _visualizer.Result.ToNumber());
+      // var binary = Expression.Binary(identifier, BinaryOperator.Multiply, Expression.Number(3));
+      // var eval = Statement.Eval(binary);
+      // _executor.Run(eval);
+      // Assert.Equal(6, _visualizer.Result.ToNumber());
     }
   }
 }

--- a/csharp/tests/SeedLang.Tests/Ast/ExecutorTests.cs
+++ b/csharp/tests/SeedLang.Tests/Ast/ExecutorTests.cs
@@ -1,3 +1,4 @@
+using System.Security.Principal;
 // Copyright 2021 The Aha001 Team.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
+using SeedLang.Common;
 using SeedLang.Runtime;
 using Xunit;
 
 namespace SeedLang.Ast.Tests {
-  public class ExecutorTests : IDisposable {
+  public class ExecutorTests {
     private class MockupVisualizer : IVisualizer<AssignmentEvent>,
                                      IVisualizer<BinaryEvent>,
                                      IVisualizer<EvalEvent> {
@@ -26,89 +27,114 @@ namespace SeedLang.Ast.Tests {
       public BinaryOperator Op { get; private set; }
       public IValue Right { get; private set; }
       public IValue Result { get; private set; }
+      public Range Range { get; private set; }
 
-      public void On(AssignmentEvent e) {
-        Identifier = e.Identifier;
-        Result = e.Value;
+      public void On(AssignmentEvent ae) {
+        Identifier = ae.Identifier;
+        Result = ae.Value;
+        Range = ae.Range;
       }
 
-      public void On(BinaryEvent e) {
-        Left = e.Left;
-        Op = e.Op;
-        Right = e.Right;
-        Result = e.Result;
+      public void On(BinaryEvent be) {
+        Left = be.Left;
+        Op = be.Op;
+        Right = be.Right;
+        Result = be.Result;
+        Range = be.Range;
       }
 
-      public void On(EvalEvent e) {
-        Result = e.Value;
+      public void On(EvalEvent ee) {
+        Result = ee.Value;
+        Range = ee.Range;
       }
-    }
-
-    private readonly MockupVisualizer _visualizer = new MockupVisualizer();
-    private readonly VisualizerCenter _visualizerCenter = new VisualizerCenter();
-    private readonly Executor _executor;
-
-    public ExecutorTests() {
-      _visualizerCenter.Register(_visualizer);
-      _executor = new Executor(_visualizerCenter);
-    }
-
-    public void Dispose() {
-      _visualizerCenter.Unregister(_visualizer);
-      GC.SuppressFinalize(this);
     }
 
     [Fact]
     public void TestExecuteBinaryExpression() {
-      // var left = Expression.Number(1);
-      // var right = Expression.Number(2);
-      // var binary = Expression.Binary(left, BinaryOperator.Add, right);
-      // _executor.Run(binary);
+      var left = Expression.Number(1, NewTextRage());
+      var right = Expression.Number(2, NewTextRage());
+      var binary = Expression.Binary(left, BinaryOperator.Add, right, NewTextRage());
 
-      // Assert.Equal(1, _visualizer.Left.ToNumber());
-      // Assert.Equal(BinaryOperator.Add, _visualizer.Op);
-      // Assert.Equal(2, _visualizer.Right.ToNumber());
-      // Assert.Equal(3, _visualizer.Result.ToNumber());
+      (var executor, var visualizer) = NewExecutorWithVisualizer();
+      executor.Run(binary);
+      Assert.Equal(1, visualizer.Left.ToNumber());
+      Assert.Equal(BinaryOperator.Add, visualizer.Op);
+      Assert.Equal(2, visualizer.Right.ToNumber());
+      Assert.Equal(3, visualizer.Result.ToNumber());
+      Assert.Equal(NewTextRage(), visualizer.Range);
     }
 
     [Fact]
     public void TestExecuteUnaryExpression() {
-      // string name = "id";
-      // var unary = Expression.Unary(UnaryOperator.Negative, Expression.Number(1));
-      // var assignment = Statement.Assignment(Expression.Identifier(name, null), unary);
-      // _executor.Run(assignment);
-      // Assert.Equal(name, _visualizer.Identifier);
-      // Assert.Equal(-1, _visualizer.Result.ToNumber());
+      string name = "id";
+      var number = Expression.Number(1, NewTextRage());
+      var unary = Expression.Unary(UnaryOperator.Negative, number, NewTextRage());
+      var identifier = Expression.Identifier(name, NewTextRage());
+      var assignment = Statement.Assignment(identifier, unary, NewTextRage());
+
+      (var executor, var visualizer) = NewExecutorWithVisualizer();
+      executor.Run(assignment);
+      Assert.Equal(name, visualizer.Identifier);
+      Assert.Equal(-1, visualizer.Result.ToNumber());
+      Assert.Equal(NewTextRage(), visualizer.Range);
     }
 
     [Fact]
     public void TestExecuteAssignmentStatement() {
-      // string name = "id";
-      // var assignment = Statement.Assignment(Expression.Identifier(name, null), Expression.Number(1));
-      // _executor.Run(assignment);
-      // Assert.Equal(name, _visualizer.Identifier);
-      // Assert.Equal(1, _visualizer.Result.ToNumber());
+      string name = "id";
+      var identifier = Expression.Identifier(name, NewTextRage());
+      var number = Expression.Number(1, NewTextRage());
+      var assignment = Statement.Assignment(identifier, number, NewTextRage());
+
+      (var executor, var visualizer) = NewExecutorWithVisualizer();
+      executor.Run(assignment);
+      Assert.Equal(name, visualizer.Identifier);
+      Assert.Equal(1, visualizer.Result.ToNumber());
+      Assert.Equal(NewTextRage(), visualizer.Range);
     }
 
     [Fact]
     public void TestExecuteEvalStatement() {
-      // var left = Expression.Binary(Expression.Number(1), BinaryOperator.Add, Expression.Number(2));
-      // var binary = Expression.Binary(left, BinaryOperator.Multiply, Expression.Number(3));
-      // var eval = Statement.Eval(binary);
-      // _executor.Run(eval);
-      // Assert.Equal(9, _visualizer.Result.ToNumber());
+      var number1 = Expression.Number(1, NewTextRage());
+      var number2 = Expression.Number(2, NewTextRage());
+      var number3 = Expression.Number(3, NewTextRage());
+      var left = Expression.Binary(number1, BinaryOperator.Add, number2, NewTextRage());
+      var binary = Expression.Binary(left, BinaryOperator.Multiply, number3, NewTextRage());
+      var eval = Statement.Eval(binary, NewTextRage());
+
+      (var executor, var visualizer) = NewExecutorWithVisualizer();
+      executor.Run(eval);
+      Assert.Equal(9, visualizer.Result.ToNumber());
+      Assert.Equal(NewTextRage(), visualizer.Range);
     }
 
     [Fact]
     public void TestExecuteEvalWithVariable() {
-      // var identifier = Expression.Identifier("a", null);
-      // var assignment = Statement.Assignment(identifier, Expression.Number(2));
-      // _executor.Run(assignment);
+      (var executor, var visualizer) = NewExecutorWithVisualizer();
 
-      // var binary = Expression.Binary(identifier, BinaryOperator.Multiply, Expression.Number(3));
-      // var eval = Statement.Eval(binary);
-      // _executor.Run(eval);
-      // Assert.Equal(6, _visualizer.Result.ToNumber());
+      var identifier = Expression.Identifier("a", NewTextRage());
+      var number = Expression.Number(2, NewTextRage());
+      var assignment = Statement.Assignment(identifier, number, NewTextRage());
+      executor.Run(assignment);
+
+      var right = Expression.Number(3, NewTextRage());
+      var binary = Expression.Binary(identifier, BinaryOperator.Multiply, right, NewTextRage());
+      var eval = Statement.Eval(binary, NewTextRage());
+      executor.Run(eval);
+      Assert.Equal(6, visualizer.Result.ToNumber());
+      Assert.Equal(NewTextRage(), visualizer.Range);
+    }
+
+    private static TextRange NewTextRage() {
+      return new TextRange(0, 1, 2, 3);
+    }
+
+    private static (Executor, MockupVisualizer) NewExecutorWithVisualizer() {
+      var visualizer = new MockupVisualizer();
+      var visualizerCenter = new VisualizerCenter();
+      visualizerCenter.Register(visualizer);
+      var executor = new Executor(visualizerCenter);
+      return (executor, visualizer);
     }
   }
 }

--- a/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
+++ b/csharp/tests/SeedLang.Tests/Interpreter/CompilerTests.cs
@@ -14,14 +14,18 @@
 
 using System;
 using SeedLang.Ast;
+using SeedLang.Common;
 using SeedLang.Runtime;
 using Xunit;
 
 namespace SeedLang.Interpreter.Tests {
   public class CompilerTests {
+    private static TextRange _testTextRange => new TextRange(0, 1, 2, 3);
+
     [Fact]
     public void TestCompileEvalNumber() {
-      var eval = Statement.Eval(Expression.Number(1));
+      var number = Expression.Number(1, _testTextRange);
+      var eval = Statement.Eval(number, _testTextRange);
       var compiler = new Compiler();
       var chunk = compiler.Compile(eval);
       string expected = (
@@ -34,9 +38,10 @@ namespace SeedLang.Interpreter.Tests {
 
     [Fact]
     public void TestCompileEvalBinary() {
-      var left = Expression.Number(1);
-      var right = Expression.Number(2);
-      var eval = Statement.Eval(Expression.Binary(left, BinaryOperator.Add, right));
+      var left = Expression.Number(1, _testTextRange);
+      var right = Expression.Number(2, _testTextRange);
+      var expr = Expression.Binary(left, BinaryOperator.Add, right, _testTextRange);
+      var eval = Statement.Eval(expr, _testTextRange);
       var compiler = new Compiler();
       var chunk = compiler.Compile(eval);
       string expected = (
@@ -49,9 +54,12 @@ namespace SeedLang.Interpreter.Tests {
 
     [Fact]
     public void TestCompileEvalComplexBinary() {
-      var left = Expression.Number(1);
-      var right = Expression.Binary(Expression.Number(2), BinaryOperator.Add, Expression.Number(3));
-      var eval = Statement.Eval(Expression.Binary(left, BinaryOperator.Subtract, right));
+      var left = Expression.Number(1, _testTextRange);
+      var number2 = Expression.Number(2, _testTextRange);
+      var number3 = Expression.Number(3, _testTextRange);
+      var right = Expression.Binary(number2, BinaryOperator.Add, number3, _testTextRange);
+      var expr = Expression.Binary(left, BinaryOperator.Subtract, right, _testTextRange);
+      var eval = Statement.Eval(expr, _testTextRange);
       var compiler = new Compiler();
       var chunk = compiler.Compile(eval);
       string expected = (
@@ -65,13 +73,16 @@ namespace SeedLang.Interpreter.Tests {
 
     [Fact]
     public void TestCompileinaryWithSameConstants() {
-      var left = Expression.Number(1);
-      var right = Expression.Binary(Expression.Number(2), BinaryOperator.Add, Expression.Number(1));
-      var eval = Statement.Eval(Expression.Binary(left, BinaryOperator.Subtract, right));
+      var left = Expression.Number(1, _testTextRange);
+      var number1 = Expression.Number(1, _testTextRange);
+      var number2 = Expression.Number(2, _testTextRange);
+      var right = Expression.Binary(number1, BinaryOperator.Add, number2, _testTextRange);
+      var expr = Expression.Binary(left, BinaryOperator.Subtract, right, _testTextRange);
+      var eval = Statement.Eval(expr, _testTextRange);
       var compiler = new Compiler();
       var chunk = compiler.Compile(eval);
       string expected = (
-          "ADD 1 251 250       \n" +
+          "ADD 1 250 251       \n" +
           "SUB 0 250 1         \n" +
           "EVAL 0              \n" +
           "RETURN 0            \n"

--- a/csharp/tests/SeedLang.Tests/X/PythonParserTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/PythonParserTests.cs
@@ -48,7 +48,7 @@ namespace SeedLang.X.Tests {
 
     // TODO: add test cases for other syntax errors after grammar is more complex.
     [Theory]
-    [InlineData("1", "SyntaxErrorInputMismatch '1' {'eval', 'break', 'continue', IDENTIFIER}")]
+    [InlineData("1", "SyntaxErrorInputMismatch '1' {'break', 'continue', 'eval', IDENTIFIER}")]
     [InlineData("eval1", @"SyntaxErrorInputMismatch '<EOF>' '='")]
     [InlineData("eval 1.2 =", @"SyntaxErrorUnwantedToken '=' <EOF>")]
     public void TestParseSingleSyntaxError(string input, string localizedMessage) {

--- a/csharp/tests/SeedLang.Tests/X/PythonParserTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/PythonParserTests.cs
@@ -39,13 +39,24 @@ namespace SeedLang.X.Tests {
 
     [Fact]
     public void TestParseEvalStatementWithRange() {
-      Assert.True(_parser.TryParse("eval 1 + 2", "", ParseRule.Statement, _collection,
-                  out AstNode node));
-      Assert.NotNull(node);
-      Assert.Equal(new TextRange(1, 5, 1, 9), (node as EvalStatement).Expr.Range);
-      Assert.Equal(new TextRange(1, 0, 1, 9), node.Range);
+      Assert.True(_parser.TryParse("eval (1 + 2) * (( 3 - -4 ))", "", ParseRule.Statement,
+                  _collection, out AstNode node));
       Assert.Empty(_collection.Diagnostics);
-      Assert.Equal("eval (1 + 2)\n", node.ToString());
+      Assert.NotNull(node);
+      Assert.Equal(new TextRange(1, 0, 1, 26), node.Range);
+      var expr = (node as EvalStatement).Expr as BinaryExpression;
+      Assert.Equal(new TextRange(1, 5, 1, 26), expr.Range);
+      var left = expr.Left as BinaryExpression;
+      Assert.Equal(new TextRange(1, 5, 1, 11), left.Range);
+      var right = expr.Right as BinaryExpression;
+      Assert.Equal(new TextRange(1, 15, 1, 26), right.Range);
+      var leftNumber = right.Left as NumberConstantExpression;
+      Assert.Equal(new TextRange(1, 18, 1, 18), leftNumber.Range);
+      var unary = right.Right as UnaryExpression;
+      Assert.Equal(new TextRange(1, 22, 1, 23), unary.Range);
+      var rightNumber = unary.Expr as NumberConstantExpression;
+      Assert.Equal(new TextRange(1, 23, 1, 23), rightNumber.Range);
+      Assert.Equal("eval ((1 + 2) * (3 - (- 4)))\n", node.ToString());
     }
 
     [Theory]

--- a/csharp/tests/SeedLang.Tests/X/PythonParserTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/PythonParserTests.cs
@@ -37,6 +37,17 @@ namespace SeedLang.X.Tests {
       Assert.Equal(expected, node.ToString());
     }
 
+    [Fact]
+    public void TestParseEvalStatementWithRange() {
+      Assert.True(_parser.TryParse("eval 1 + 2", "", ParseRule.Statement, _collection,
+                  out AstNode node));
+      Assert.NotNull(node);
+      Assert.Equal(new TextRange(1, 5, 1, 9), (node as EvalStatement).Expr.Range);
+      Assert.Equal(new TextRange(1, 0, 1, 9), node.Range);
+      Assert.Empty(_collection.Diagnostics);
+      Assert.Equal("eval (1 + 2)\n", node.ToString());
+    }
+
     [Theory]
     [InlineData("eval 1 + 2 * 3 - 4", "eval ((1 + (2 * 3)) - 4)\n")]
     public void TestParseEvalStatement(string input, string expected) {

--- a/grammars/Common.g4
+++ b/grammars/Common.g4
@@ -36,6 +36,8 @@ expr:
  * Lexer rules
  */
 
+EVAL: 'eval';
+
 ADD: '+';
 SUB: '-';
 MUL: '*';

--- a/grammars/Common.g4
+++ b/grammars/Common.g4
@@ -25,12 +25,12 @@ grammar Common;
  */
 
 expr:
-  op = SUB expr                # unary
-  | expr op = (MUL | DIV) expr # mul_div
-  | expr op = (ADD | SUB) expr # add_sub
-  | IDENTIFIER                 # identifier
-  | NUMBER                     # number
-  | '(' expr ')'               # grouping;
+  op = SUB expr                 # unary
+  | expr op = (MUL | DIV) expr  # mul_div
+  | expr op = (ADD | SUB) expr  # add_sub
+  | IDENTIFIER                  # identifier
+  | NUMBER                      # number
+  | OPEN_PAREN expr CLOSE_PAREN # grouping;
 
 /*
  * Lexer rules

--- a/grammars/SeedPython.g4
+++ b/grammars/SeedPython.g4
@@ -66,7 +66,7 @@ simple_stmt: small_stmt (';' small_stmt)* (';')?;
 small_stmt: assign_stmt | eval_stmt | flow_stmt;
 
 assign_stmt: IDENTIFIER '=' expr;
-eval_stmt: 'eval' expr;
+eval_stmt: EVAL expr;
 flow_stmt: break_stmt | continue_stmt;
 break_stmt: 'break';
 continue_stmt: 'continue';


### PR DESCRIPTION
- The source code range could be BlockRange or TextRange.
- The range information is embedded in the AST node structure now.
- The range information is notified along with visualization events.
- SeedLang shell can highlight current visualized expression pf SeedPython.

Known issue: left and right parenthesis are not counted in the range corrected, because parenthesis information is removed from AST nodes. Need another way to handle it.