### PR TITLE
Upgrade to dotnet 6.0

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Restore dependencies
         working-directory: ./csharp
         run: dotnet restore

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/csharp/src/SeedLang.Shell/bin/Debug/net5.0/SeedLang.Shell.dll",
+      "program": "${workspaceFolder}/csharp/src/SeedLang.Shell/bin/Debug/net6.0/SeedLang.Shell.dll",
       "args": [],
       "cwd": "${workspaceFolder}/csharp/src/SeedLang",
       // Use integratedTerminal to allow reading from the console.

--- a/csharp/benchmark/SeedLang.Benchmark/SeedLang.Benchmark.csproj
+++ b/csharp/benchmark/SeedLang.Benchmark/SeedLang.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/src/SeedLang.Shell/SeedLang.Shell.csproj
+++ b/csharp/src/SeedLang.Shell/SeedLang.Shell.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageId>SeedLang.Shell</PackageId>
     <ReleaseTag>preview</ReleaseTag>
     <VersionPrefix>0.1.2</VersionPrefix>

--- a/csharp/src/SeedLang/SeedLang.csproj
+++ b/csharp/src/SeedLang/SeedLang.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <PackageId>SeedLang</PackageId>
     <ReleaseTag>preview</ReleaseTag>
     <VersionPrefix>0.1.2</VersionPrefix>

--- a/csharp/tests/SeedLang.Tests/SeedLang.Tests.csproj
+++ b/csharp/tests/SeedLang.Tests/SeedLang.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Upgrade dotnet framework from 5.0 to 6.0 for shell, unit test and benchmark projects, because arm64 Mac osx is support in dotnet v6. There is significant performance increment in this version for development on Apple M1 laptop.