### PR TITLE
Implement SeedCalc language

### DIFF
--- a/csharp/src/SeedLang/Block/Converter.cs
+++ b/csharp/src/SeedLang/Block/Converter.cs
@@ -29,7 +29,7 @@ namespace SeedLang.Block {
                           Message.EmptyInlineText);
         return false;
       }
-      var parser = new BlockInlineTextParser();
+      var parser = new SeedBlockInlineText();
       return parser.Validate(text, "", collection);
     }
 
@@ -42,7 +42,7 @@ namespace SeedLang.Block {
                           Message.EmptyInlineText);
         return null;
       }
-      var parser = new BlockInlineTextParser();
+      var parser = new SeedBlockInlineText();
       if (!parser.Parse(text, "", collection, out _, out IReadOnlyList<SyntaxToken> tokens)) {
         return null;
       }
@@ -96,7 +96,7 @@ namespace SeedLang.Block {
         foreach (var rootBlock in module.RootBlockIterator) {
           // TODO: implement a visitor to parse other kinds of blocks.
           if (rootBlock is ExpressionBlock expressionBlock) {
-            var parser = new BlockInlineTextParser();
+            var parser = new SeedBlockInlineText();
             if (parser.Parse(expressionBlock.GetEditableText(), module.Name, collection,
                              out AstNode node, out IReadOnlyList<SyntaxToken> _)) {
               nodes.Add(node);

--- a/csharp/src/SeedLang/Common/Message.cs
+++ b/csharp/src/SeedLang/Common/Message.cs
@@ -74,6 +74,7 @@ namespace SeedLang.Common {
     SyntaxErrorFailedPredicate1,        // Semantic predicate failed syntax error.
     SyntaxErrorInputMismatch2,          // Input mismatch syntax error.
     SyntaxErrorMissingToken2,           // Missing token syntax error.
+    SyntaxErrorNestedUnary,             // Syntax error for SeedCalc. Nested unary is not allowed.
     SyntaxErrorNoViableAlternative1,    // No viable alternative path syntax error.
     SyntaxErrorUnwantedToken2,          // Unwanted token syntax error.
     TargetBlockIdNotExist1,             // Target block ID does not exist.

--- a/csharp/src/SeedLang/Common/Message.cs
+++ b/csharp/src/SeedLang/Common/Message.cs
@@ -74,7 +74,6 @@ namespace SeedLang.Common {
     SyntaxErrorFailedPredicate1,        // Semantic predicate failed syntax error.
     SyntaxErrorInputMismatch2,          // Input mismatch syntax error.
     SyntaxErrorMissingToken2,           // Missing token syntax error.
-    SyntaxErrorNestedUnary,             // Syntax error for SeedCalc. Nested unary is not allowed.
     SyntaxErrorNoViableAlternative1,    // No viable alternative path syntax error.
     SyntaxErrorUnwantedToken2,          // Unwanted token syntax error.
     TargetBlockIdNotExist1,             // Target block ID does not exist.

--- a/csharp/src/SeedLang/Runtime/Executor.cs
+++ b/csharp/src/SeedLang/Runtime/Executor.cs
@@ -99,10 +99,12 @@ namespace SeedLang.Runtime {
 
     private static BaseParser MakeParser(SeedXLanguage language) {
       switch (language) {
-        case SeedXLanguage.BlockInlineText:
-          return new BlockInlineTextParser();
+        case SeedXLanguage.SeedBlockInlineText:
+          return new SeedBlockInlineText();
+        case SeedXLanguage.SeedCalc:
+          return new SeedCalc();
         case SeedXLanguage.SeedPython:
-          return new PythonParser();
+          return new SeedPython();
         default:
           throw new NotImplementedException($"Unsupported SeedX language: {language}.");
       }

--- a/csharp/src/SeedLang/Runtime/SeedXLanguage.cs
+++ b/csharp/src/SeedLang/Runtime/SeedXLanguage.cs
@@ -15,7 +15,8 @@
 namespace SeedLang.Runtime {
   // All supported languages include block inline text and other SeedX languages.
   public enum SeedXLanguage {
-    BlockInlineText,
+    SeedBlockInlineText,
+    SeedCalc,
     SeedPython,
   }
 }

--- a/csharp/src/SeedLang/SeedLang.csproj
+++ b/csharp/src/SeedLang/SeedLang.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Antlr4 Include="../../../grammars/SeedPython.g4">
+    <Antlr4 Include="../../../grammars/SeedBlockInlineText.g4">
         <Listener>false</Listener>
         <Visitor>true</Visitor>
         <GAtn>false</GAtn>
@@ -34,7 +34,15 @@
         <Error>true</Error>
         <LibPath>../../../grammars</LibPath>
     </Antlr4>
-    <Antlr4 Include="../../../grammars/SeedBlockInlineText.g4">
+    <Antlr4 Include="../../../grammars/SeedCalc.g4">
+        <Listener>false</Listener>
+        <Visitor>true</Visitor>
+        <GAtn>false</GAtn>
+        <Package>SeedLang.X</Package>
+        <Error>true</Error>
+        <LibPath>../../../grammars</LibPath>
+    </Antlr4>
+    <Antlr4 Include="../../../grammars/SeedPython.g4">
         <Listener>false</Listener>
         <Visitor>true</Visitor>
         <GAtn>false</GAtn>

--- a/csharp/src/SeedLang/X/BaseParser.cs
+++ b/csharp/src/SeedLang/X/BaseParser.cs
@@ -62,11 +62,8 @@ namespace SeedLang.X {
 
     protected abstract AbstractParseTreeVisitor<AstNode> MakeVisitor(IList<SyntaxToken> tokens);
 
-    // Returns the parser rule context of a program. This method must be implemented by the derived
-    // class.
-    protected virtual ParserRuleContext Program(Parser parser) {
-      throw new NotImplementedException();
-    }
+    // Returns the parser rule context of a program.
+    protected abstract ParserRuleContext Program(Parser parser);
 
     protected Lexer SetupLexer(string source) {
       var inputStream = new AntlrInputStream(source);

--- a/csharp/src/SeedLang/X/SeedBlockInlineText.cs
+++ b/csharp/src/SeedLang/X/SeedBlockInlineText.cs
@@ -18,14 +18,10 @@ using Antlr4.Runtime;
 using Antlr4.Runtime.Tree;
 using SeedLang.Ast;
 using SeedLang.Common;
-using SeedLang.X;
 
-namespace SeedLang.Block {
+namespace SeedLang.X {
   // The parser to parse a block inline text of SeedBlock programs.
-  //
-  // The BlockInlineTextParser uses generated ANTLR4 SeedBlockInlineTextParser to parse the inline
-  // text of block programs.
-  internal class BlockInlineTextParser : BaseParser {
+  internal class SeedBlockInlineText : BaseParser {
     // The dictionary that maps from token types of SeedBlock to syntax token types.
     private readonly Dictionary<int, SyntaxType> _syntaxTypes = new Dictionary<int, SyntaxType> {
       { SeedBlockInlineTextParser.NAME, SyntaxType.Variable},
@@ -59,7 +55,7 @@ namespace SeedLang.Block {
     }
 
     protected override AbstractParseTreeVisitor<AstNode> MakeVisitor(IList<SyntaxToken> tokens) {
-      return new BlockInlineTextVisitor(tokens);
+      return new SeedBlockInlineTextVisitor(tokens);
     }
 
     protected override ParserRuleContext Program(Parser parser) {

--- a/csharp/src/SeedLang/X/SeedBlockInlineTextVisitor.cs
+++ b/csharp/src/SeedLang/X/SeedBlockInlineTextVisitor.cs
@@ -19,19 +19,18 @@ using Antlr4.Runtime.Misc;
 using SeedLang.Ast;
 using SeedLang.Common;
 using SeedLang.Runtime;
-using SeedLang.X;
 
-namespace SeedLang.Block {
+namespace SeedLang.X {
   // The visitor class to visit a block inline text of SeedBlock programs and generate the
   // corresponding AST tree.
   //
   // The default implement of SeedBlockInlineTextBaseVisitor is to visit all the children and return
-  // the result of the last one. BlockInlineTextVisitor overrides the method if the default
+  // the result of the last one. SeedBlockInlineTextVisitor overrides the method if the default
   // implement is not correct.
-  internal class BlockInlineTextVisitor : SeedBlockInlineTextBaseVisitor<AstNode> {
+  internal class SeedBlockInlineTextVisitor : SeedBlockInlineTextBaseVisitor<AstNode> {
     private readonly VisitorHelper _helper;
 
-    public BlockInlineTextVisitor(IList<SyntaxToken> tokens) {
+    public SeedBlockInlineTextVisitor(IList<SyntaxToken> tokens) {
       _helper = new VisitorHelper(tokens);
     }
 

--- a/csharp/src/SeedLang/X/SeedCalc.cs
+++ b/csharp/src/SeedLang/X/SeedCalc.cs
@@ -1,0 +1,57 @@
+// Copyright 2021 The Aha001 Team.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Tree;
+using SeedLang.Ast;
+using SeedLang.Common;
+
+namespace SeedLang.X {
+  // The parser of SeedCalc language.
+  internal class SeedCalc : BaseParser {
+    // The dictionary that maps from token types of SeedCalc to syntax token types.
+    private readonly Dictionary<int, SyntaxType> _syntaxTypes = new Dictionary<int, SyntaxType> {
+      { SeedCalcParser.NUMBER, SyntaxType.Number },
+      { SeedCalcParser.ADD, SyntaxType.Operator },
+      { SeedCalcParser.SUBTRACT, SyntaxType.Operator },
+      { SeedCalcParser.MULTIPLY, SyntaxType.Operator },
+      { SeedCalcParser.DIVIDE, SyntaxType.Operator },
+      { SeedCalcParser.OPEN_PAREN, SyntaxType.Parenthesis },
+      { SeedCalcParser.CLOSE_PAREN, SyntaxType.Parenthesis },
+      { SeedCalcParser.UNKNOWN_CHAR, SyntaxType.Unknown },
+    };
+
+    // The dictionary that maps from token types of SeedPython to syntax token types.
+    protected override IReadOnlyDictionary<int, SyntaxType> _syntaxTypeMap => _syntaxTypes;
+
+    protected override Lexer MakeLexer(ICharStream stream) {
+      return new SeedCalcLexer(stream);
+    }
+
+    protected override Parser MakeParser(ITokenStream stream) {
+      return new SeedCalcParser(stream);
+    }
+
+    protected override AbstractParseTreeVisitor<AstNode> MakeVisitor(IList<SyntaxToken> tokens) {
+      return new SeedCalcVisitor(tokens);
+    }
+
+    protected override ParserRuleContext Program(Parser parser) {
+      Debug.Assert(parser is SeedCalcParser, $"Incorrect parser type: {parser}");
+      return (parser as SeedCalcParser).expressionStatement();
+    }
+  }
+}

--- a/csharp/src/SeedLang/X/SeedCalc.cs
+++ b/csharp/src/SeedLang/X/SeedCalc.cs
@@ -34,7 +34,7 @@ namespace SeedLang.X {
       { SeedCalcParser.UNKNOWN_CHAR, SyntaxType.Unknown },
     };
 
-    // The dictionary that maps from token types of SeedPython to syntax token types.
+    // The dictionary that maps from token types of SeedCalc to syntax token types.
     protected override IReadOnlyDictionary<int, SyntaxType> _syntaxTypeMap => _syntaxTypes;
 
     protected override Lexer MakeLexer(ICharStream stream) {

--- a/csharp/src/SeedLang/X/SeedCalcVisitor.cs
+++ b/csharp/src/SeedLang/X/SeedCalcVisitor.cs
@@ -1,0 +1,77 @@
+// Copyright 2021 The Aha001 Team.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Antlr4.Runtime.Misc;
+using SeedLang.Ast;
+using SeedLang.Common;
+using SeedLang.Runtime;
+
+namespace SeedLang.X {
+  // The visitor class to visit a SeedCalc expression and generate the corresponding AST tree.
+  //
+  // The default implement of SeedCalcBaseVisitor is to visit all the children and return the result
+  // of the last one. SeedCalcVisitor overrides the methods if the default implement is not correct.
+  internal class SeedCalcVisitor : SeedCalcBaseVisitor<AstNode> {
+    private readonly VisitorHelper _helper;
+
+    public SeedCalcVisitor(IList<SyntaxToken> tokens) {
+      _helper = new VisitorHelper(tokens);
+    }
+
+    public override AstNode VisitExpressionStatement(
+        [NotNull] SeedCalcParser.ExpressionStatementContext context) {
+      return Visit(context.expression());
+    }
+
+    public override AstNode VisitAdd([NotNull] SeedCalcParser.AddContext context) {
+      return _helper.BuildBinary(context.sum(), context.ADD().Symbol, BinaryOperator.Add,
+                                 context.term(), this);
+    }
+
+    public override AstNode VisitSubtract([NotNull] SeedCalcParser.SubtractContext context) {
+      return _helper.BuildBinary(context.sum(), context.SUBTRACT().Symbol, BinaryOperator.Subtract,
+                                 context.term(), this);
+    }
+
+    public override AstNode VisitDivide([NotNull] SeedCalcParser.DivideContext context) {
+      return _helper.BuildBinary(context.term(), context.DIVIDE().Symbol, BinaryOperator.Divide,
+                                 context.factor(), this);
+    }
+
+    public override AstNode VisitMultiply([NotNull] SeedCalcParser.MultiplyContext context) {
+      return _helper.BuildBinary(context.term(), context.MULTIPLY().Symbol, BinaryOperator.Multiply,
+                                 context.factor(), this);
+    }
+
+    public override AstNode VisitPositive([NotNull] SeedCalcParser.PositiveContext context) {
+      return _helper.BuildUnary(context.ADD().Symbol, UnaryOperator.Positive, context.atom(),
+                                this);
+    }
+
+    public override AstNode VisitNegative([NotNull] SeedCalcParser.NegativeContext context) {
+      return _helper.BuildUnary(context.SUBTRACT().Symbol, UnaryOperator.Negative,
+                                context.atom(), this);
+    }
+
+    public override AstNode VisitNumber([NotNull] SeedCalcParser.NumberContext context) {
+      return _helper.BuildNumberConstant(context.NUMBER().Symbol);
+    }
+
+    public override AstNode VisitGroup([NotNull] SeedCalcParser.GroupContext context) {
+      return _helper.BuildGrouping(context.OPEN_PAREN().Symbol, context.expression(),
+                                   context.CLOSE_PAREN().Symbol, this);
+    }
+  }
+}

--- a/csharp/src/SeedLang/X/SeedPython.cs
+++ b/csharp/src/SeedLang/X/SeedPython.cs
@@ -21,7 +21,7 @@ using SeedLang.Common;
 
 namespace SeedLang.X {
   // The parser of SeedPython language.
-  internal class PythonParser : BaseParser {
+  internal class SeedPython : BaseParser {
     // The dictionary that maps from token types of SeedPython to syntax token types.
     private readonly Dictionary<int, SyntaxType> _syntaxTypes = new Dictionary<int, SyntaxType> {
       { SeedPythonParser.NAME, SyntaxType.Variable },
@@ -31,6 +31,8 @@ namespace SeedLang.X {
       { SeedPythonParser.MULTIPLY, SyntaxType.Operator },
       { SeedPythonParser.DIVIDE, SyntaxType.Operator },
       { SeedPythonParser.FLOOR_DIVIDE, SyntaxType.Operator },
+      { SeedPythonParser.POWER, SyntaxType.Operator },
+      { SeedPythonParser.MODULO, SyntaxType.Operator },
       { SeedPythonParser.EQUAL, SyntaxType.Operator },
       { SeedPythonParser.EQ_EQUAL, SyntaxType.Operator },
       { SeedPythonParser.NOT_EQUAL, SyntaxType.Operator },
@@ -56,7 +58,7 @@ namespace SeedLang.X {
     }
 
     protected override AbstractParseTreeVisitor<AstNode> MakeVisitor(IList<SyntaxToken> tokens) {
-      return new PythonVisitor(tokens);
+      return new SeedPythonVisitor(tokens);
     }
 
     protected override ParserRuleContext Program(Parser parser) {

--- a/csharp/src/SeedLang/X/SeedPythonVisitor.cs
+++ b/csharp/src/SeedLang/X/SeedPythonVisitor.cs
@@ -24,12 +24,12 @@ namespace SeedLang.X {
   // The visitor class to visit a SeedPython parse tree and generate the corresponding AST tree.
   //
   // The default implement of SeedPythonBaseVisitor is to visit all the children and return the
-  // result of the last one. PythonVisitor overrides the method if the default implement is not
+  // result of the last one. SeedPythonVisitor overrides the method if the default implement is not
   // correct.
-  internal class PythonVisitor : SeedPythonBaseVisitor<AstNode> {
+  internal class SeedPythonVisitor : SeedPythonBaseVisitor<AstNode> {
     private readonly VisitorHelper _helper;
 
-    public PythonVisitor(IList<SyntaxToken> tokens) {
+    public SeedPythonVisitor(IList<SyntaxToken> tokens) {
       _helper = new VisitorHelper(tokens);
     }
 

--- a/csharp/tests/SeedLang.Tests/X/SeedBlockInlineTextTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedBlockInlineTextTests.cs
@@ -19,7 +19,7 @@ using SeedLang.Common;
 using Xunit;
 
 namespace SeedLang.X.Tests {
-  public class BlockInlineTextParserTests {
+  public class SeedBlockInlineTextTests {
     private readonly DiagnosticCollection _collection = new DiagnosticCollection();
     private readonly SeedBlockInlineText _parser = new SeedBlockInlineText();
 

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonErrorTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonErrorTests.cs
@@ -19,9 +19,9 @@ using SeedLang.Common;
 using Xunit;
 
 namespace SeedLang.X.Tests {
-  public class PythonParserErrorTests {
+  public class SeedPythonErrorTests {
     private readonly DiagnosticCollection _collection = new DiagnosticCollection();
-    private readonly PythonParser _parser = new PythonParser();
+    private readonly SeedPython _parser = new SeedPython();
 
     [Theory]
     [InlineData("1.2 =",

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonTests.cs
@@ -19,9 +19,9 @@ using SeedLang.Common;
 using Xunit;
 
 namespace SeedLang.X.Tests {
-  public class PythonParserTests {
+  public class SeedPythonTests {
     private readonly DiagnosticCollection _collection = new DiagnosticCollection();
-    private readonly PythonParser _parser = new PythonParser();
+    private readonly SeedPython _parser = new SeedPython();
 
     [Theory]
     [InlineData("1 + 2 * 3 - 4\n", true)]

--- a/grammars/Common.g4
+++ b/grammars/Common.g4
@@ -137,9 +137,9 @@ DECIMAL_INTEGER: NON_ZERO_DIGIT DIGIT* | '0'+;
 
 FLOAT_NUMBER: POINT_FLOAT | EXPONENT_FLOAT;
 
-NEWLINE: ( '\r'? '\n' | '\r' | '\f') SPACES?;
+NEWLINE: ('\r'? '\n' | '\r' | '\f') SPACES?;
 
-SKIP_: ( SPACES | COMMENT | LINE_JOINING) -> skip;
+SKIP_: (SPACES | COMMENT | LINE_JOINING) -> skip;
 
 UNKNOWN_CHAR: .;
 

--- a/grammars/SeedCalc.g4
+++ b/grammars/SeedCalc.g4
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 The Aha001 Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SeedPyhton grammar is referred and modified from:
+ * https://docs.python.org/3.10/reference/grammar.html
+*/
+
+grammar SeedCalc;
+
+@header {
+  #pragma warning disable 3021
+}
+
+/*
+ * Parser rules
+ */
+
+expressionStatement: expression EOF;
+
+expression: sum;
+
+sum:
+  sum ADD term        # add
+  | sum SUBTRACT term # subtract
+  | term              # term_as_sum;
+term:
+  term MULTIPLY factor # multiply
+  | term DIVIDE factor # divide
+  | factor             # factor_as_term;
+factor:
+  ADD atom        # positive
+  | SUBTRACT atom # negative
+  | atom          # atom_as_factor;
+atom: NUMBER # number | group # group_as_atom;
+
+group: OPEN_PAREN expression CLOSE_PAREN;
+
+/*
+ * Lexer rules
+ */
+
+ADD: '+';
+SUBTRACT: '-';
+MULTIPLY: '*';
+DIVIDE: '/';
+
+OPEN_PAREN: '(';
+CLOSE_PAREN: ')';
+
+NUMBER: INTEGER | FLOAT_NUMBER;
+
+INTEGER: DECIMAL_INTEGER;
+
+DECIMAL_INTEGER: NON_ZERO_DIGIT DIGIT* | '0'+;
+
+FLOAT_NUMBER: POINT_FLOAT | EXPONENT_FLOAT;
+
+SKIP_: SPACES -> skip;
+
+UNKNOWN_CHAR: .;
+
+/*
+ * Fragments
+ */
+
+fragment POINT_FLOAT:
+  INT_PART? FRACTION
+  | INT_PART '.';
+
+fragment EXPONENT_FLOAT: (INT_PART | POINT_FLOAT) EXPONENT;
+
+fragment INT_PART: DIGIT+;
+
+fragment FRACTION: '.' DIGIT+;
+
+fragment EXPONENT: [eE] [+-]? DIGIT+;
+
+fragment NON_ZERO_DIGIT: [1-9];
+
+fragment DIGIT: [0-9];
+
+fragment SPACES: [ \t]+;


### PR DESCRIPTION
Fix #93

- Support `+`, `-`, `*`, `/`, `(`, `)` in SeedCalc
- Support unary expressions like `1 + +2`, `1 + -2`
- Report syntax errors for unary expressions like `1+ + -2`
- Support unary expressions like `1 + +(-(+2))`

One point need be considered later:
Our original idea is all the SeedX languages can be converted to other languages through AST, because they all support same syntax units. But SeedCalc only support very simple expressions. It cannot be converted from or to other languages.