### PR TITLE
Refactor SeedLang Shell

### DIFF
--- a/csharp/src/SeedLang.Shell/Program.cs
+++ b/csharp/src/SeedLang.Shell/Program.cs
@@ -19,11 +19,13 @@ using CommandLine.Text;
 using SeedLang.Runtime;
 
 namespace SeedLang.Shell {
+  // The visualizer type. Uses All to enable all visualizers.
   internal enum VisualizerType {
     Assignment,
     Binary,
     Comparison,
     Eval,
+    All,
   }
 
   internal class Program {
@@ -37,7 +39,7 @@ namespace SeedLang.Shell {
 
       [Option('v', "visualizers", Required = false,
               Default = new VisualizerType[] { VisualizerType.Eval },
-              HelpText = "Enabled Visualizers")]
+              HelpText = "The Visualizers need to be enabled.")]
       public IEnumerable<VisualizerType> VisualizerTypes { get; set; }
     }
 

--- a/csharp/src/SeedLang.Shell/Program.cs
+++ b/csharp/src/SeedLang.Shell/Program.cs
@@ -13,11 +13,19 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using CommandLine;
 using CommandLine.Text;
 using SeedLang.Runtime;
 
 namespace SeedLang.Shell {
+  internal enum VisualizerType {
+    Assignment,
+    Binary,
+    Comparison,
+    Eval,
+  }
+
   internal class Program {
     internal class Options {
       [Option('l', "language", Required = false, Default = SeedXLanguage.SeedPython,
@@ -26,19 +34,24 @@ namespace SeedLang.Shell {
 
       [Option('t', "type", Required = false, Default = RunType.Ast, HelpText = "Run type.")]
       public RunType RunType { get; set; }
+
+      [Option('v', "visualizers", Required = false,
+              Default = new VisualizerType[] { VisualizerType.Eval },
+              HelpText = "Enabled Visualizers")]
+      public IEnumerable<VisualizerType> VisualizerTypes { get; set; }
     }
 
     static void Main(string[] args) {
-      var parser = new CommandLine.Parser(with => with.HelpWriter = null);
+      var parser = new Parser(with => with.HelpWriter = null);
       var result = parser.ParseArguments<Options>(args);
       var helpText = HelpText.AutoBuild(result, h => {
         h.AddEnumValuesToHelpText = true;
         return HelpText.DefaultParsingErrorsHandler(result, h);
       }, e => e);
       result.WithParsed(options => {
-        Console.Error.WriteLine(helpText.Heading);
-        Console.Error.WriteLine(helpText.Copyright);
-        Console.Error.WriteLine();
+        Console.WriteLine(helpText.Heading);
+        Console.WriteLine(helpText.Copyright);
+        Console.WriteLine();
         Run(options);
       }).WithNotParsed(errors => {
         Console.Error.WriteLine(helpText);
@@ -46,7 +59,7 @@ namespace SeedLang.Shell {
     }
 
     private static void Run(Options options) {
-      var repl = new Repl(options.Language, options.RunType);
+      var repl = new Repl(options.Language, options.RunType, options.VisualizerTypes);
       repl.Execute();
     }
   }

--- a/csharp/src/SeedLang.Shell/Repl.cs
+++ b/csharp/src/SeedLang.Shell/Repl.cs
@@ -37,12 +37,11 @@ namespace SeedLang.Shell {
       var executor = new Executor();
       _visualizerManager.RegisterToExecutor(executor);
       while (true) {
-        _source.Source = ReadLine.Read(">>> ");
+        _source.Read();
         if (_source.Source == "quit") {
           break;
         }
-        IReadOnlyList<SyntaxToken> syntaxTokens =
-            Executor.ParseSyntaxTokens(_source.Source, "", _language);
+        var syntaxTokens = Executor.ParseSyntaxTokens(_source.Source, "", _language);
         _source.WriteSourceWithSyntaxTokens(syntaxTokens);
         Console.WriteLine("---------- Run ----------");
         var runCollection = new DiagnosticCollection();
@@ -51,7 +50,7 @@ namespace SeedLang.Shell {
           if (diagnostic.Range is TextRange range) {
             _source.WriteSourceWithHighlight(range);
           }
-          Console.WriteLine(diagnostic);
+          Console.WriteLine($": {diagnostic}");
         }
         Console.WriteLine();
       }

--- a/csharp/src/SeedLang.Shell/Repl.cs
+++ b/csharp/src/SeedLang.Shell/Repl.cs
@@ -20,102 +20,42 @@ using SeedLang.Runtime;
 namespace SeedLang.Shell {
   // A Read-Evaluate-Print-Loop class to execute SeedX programs interactively.
   internal sealed class Repl {
-    private class Visualizer : IVisualizer<AssignmentEvent>,
-                               IVisualizer<BinaryEvent>,
-                               IVisualizer<ComparisonEvent>,
-                               IVisualizer<EvalEvent> {
-      // Current executed source code.
-      public SourceCode SourceCode { get; } = new SourceCode();
-
-      private readonly Dictionary<BinaryOperator, string> _binaryOperatorStrings =
-          new Dictionary<BinaryOperator, string>() {
-            {BinaryOperator.Add, "+"},
-            {BinaryOperator.Subtract, "-"},
-            {BinaryOperator.Multiply, "*"},
-            {BinaryOperator.Divide, "/"},
-            {BinaryOperator.FloorDivide, "//"},
-            {BinaryOperator.Power, "**"},
-            {BinaryOperator.Modulo, "%"},
-          };
-
-      private readonly Dictionary<ComparisonOperator, string> _comparisonOperatorStrings =
-          new Dictionary<ComparisonOperator, string>() {
-            {ComparisonOperator.Less, "<"},
-            {ComparisonOperator.Greater, ">"},
-            {ComparisonOperator.LessEqual, "<="},
-            {ComparisonOperator.GreaterEqual, ">="},
-            {ComparisonOperator.EqEqual, "=="},
-            {ComparisonOperator.NotEqual, "!="},
-          };
-
-      public void On(AssignmentEvent ae) {
-        if (ae.Range is TextRange range) {
-          SourceCode.WriteSourceWithHighlight(range);
-        }
-        Console.WriteLine($"{ae.Identifier} = {ae.Value}");
-      }
-
-      public void On(BinaryEvent be) {
-        if (be.Range is TextRange range) {
-          SourceCode.WriteSourceWithHighlight(range);
-        }
-        Console.WriteLine($"{be.Left} {_binaryOperatorStrings[be.Op]} {be.Right} = {be.Result}");
-      }
-
-      public void On(ComparisonEvent ce) {
-        if (ce.Range is TextRange range) {
-          SourceCode.WriteSourceWithHighlight(range);
-        }
-        Console.Write($"{ce.First} ");
-        for (int i = 0; i < ce.Ops.Length; ++i) {
-          string exprString = ce.Values[i] is IValue value ? value.String : "?";
-          Console.Write($"{_comparisonOperatorStrings[ce.Ops[i]]} {exprString} ");
-        }
-        Console.WriteLine($"= {ce.Result}");
-      }
-
-      public void On(EvalEvent ee) {
-        if (ee.Range is TextRange range) {
-          SourceCode.WriteSourceWithHighlight(range);
-        }
-        Console.WriteLine($"Eval result: {ee.Value}");
-      }
-
-    }
-
     private readonly SeedXLanguage _language;
     private readonly RunType _runType;
+    private readonly VisualizerManager _visualizerManager;
+    private readonly SourceCode _source = new SourceCode();
 
-    internal Repl(SeedXLanguage language, RunType runType) {
+    internal Repl(SeedXLanguage language, RunType runType,
+                  IEnumerable<VisualizerType> visualizerTypes) {
       _language = language;
       _runType = runType;
+      _visualizerManager = new VisualizerManager(_source, visualizerTypes);
     }
 
     internal void Execute() {
       ReadLine.HistoryEnabled = true;
-      var visualizer = new Visualizer();
       var executor = new Executor();
-      executor.Register(visualizer);
+      _visualizerManager.RegisterToExecutor(executor);
       while (true) {
-        visualizer.SourceCode.Source = ReadLine.Read(">>> ");
-        if (visualizer.SourceCode.Source == "quit") {
+        _source.Source = ReadLine.Read(">>> ");
+        if (_source.Source == "quit") {
           break;
         }
         IReadOnlyList<SyntaxToken> syntaxTokens =
-            Executor.ParseSyntaxTokens(visualizer.SourceCode.Source, "", _language);
-        visualizer.SourceCode.WriteSourceWithSyntaxTokens(syntaxTokens);
+            Executor.ParseSyntaxTokens(_source.Source, "", _language);
+        _source.WriteSourceWithSyntaxTokens(syntaxTokens);
         Console.WriteLine("---------- Run ----------");
         var runCollection = new DiagnosticCollection();
-        executor.Run(visualizer.SourceCode.Source, "", _language, _runType, runCollection);
+        executor.Run(_source.Source, "", _language, _runType, runCollection);
         foreach (var diagnostic in runCollection.Diagnostics) {
           if (diagnostic.Range is TextRange range) {
-            visualizer.SourceCode.WriteSourceWithHighlight(range);
+            _source.WriteSourceWithHighlight(range);
           }
           Console.WriteLine(diagnostic);
         }
         Console.WriteLine();
       }
-      executor.Unregister(visualizer);
+      _visualizerManager.UnregisterFromExecutor(executor);
     }
   }
 }

--- a/csharp/src/SeedLang.Shell/VisualizerManager.cs
+++ b/csharp/src/SeedLang.Shell/VisualizerManager.cs
@@ -1,0 +1,144 @@
+// Copyright 2021 The Aha001 Team.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using SeedLang.Common;
+using SeedLang.Runtime;
+
+namespace SeedLang.Shell {
+  internal class VisualizerManager {
+    private class Visualizer<Event> : IVisualizer<Event> where Event : AbstractEvent {
+      private readonly Action<TextRange> _writeSourceWithHighlight;
+      private readonly Action<AbstractEvent> _writeEvent;
+
+      public Visualizer(Action<TextRange> writeSourceWithHighlight,
+                        Action<AbstractEvent> writeEvent) {
+        _writeSourceWithHighlight = writeSourceWithHighlight;
+        _writeEvent = writeEvent;
+      }
+      public void On(Event e) {
+        if (e.Range is TextRange range) {
+          _writeSourceWithHighlight(range);
+        }
+        _writeEvent(e);
+      }
+    }
+
+    private readonly Dictionary<BinaryOperator, string> _binaryOperatorStrings =
+        new Dictionary<BinaryOperator, string>() {
+          {BinaryOperator.Add, "+"},
+          {BinaryOperator.Subtract, "-"},
+          {BinaryOperator.Multiply, "*"},
+          {BinaryOperator.Divide, "/"},
+          {BinaryOperator.FloorDivide, "//"},
+          {BinaryOperator.Power, "**"},
+          {BinaryOperator.Modulo, "%"},
+        };
+
+    private readonly Dictionary<ComparisonOperator, string> _comparisonOperatorStrings =
+        new Dictionary<ComparisonOperator, string>() {
+          {ComparisonOperator.Less, "<"},
+          {ComparisonOperator.Greater, ">"},
+          {ComparisonOperator.LessEqual, "<="},
+          {ComparisonOperator.GreaterEqual, ">="},
+          {ComparisonOperator.EqEqual, "=="},
+          {ComparisonOperator.NotEqual, "!="},
+        };
+
+    private readonly SourceCode _source;
+    private readonly Visualizer<AssignmentEvent> _assignmentVisualizer;
+    private readonly Visualizer<BinaryEvent> _binaryVisualizer;
+    private readonly Visualizer<ComparisonEvent> _comparisonVisualizer;
+    private readonly Visualizer<EvalEvent> _evalVisualizer;
+
+    internal VisualizerManager(SourceCode source, IEnumerable<VisualizerType> visualizerTypes) {
+      _source = source;
+      foreach (VisualizerType type in visualizerTypes) {
+        switch (type) {
+          case VisualizerType.Assignment:
+            _assignmentVisualizer = new Visualizer<AssignmentEvent>(
+                _source.WriteSourceWithHighlight, WriteEvent);
+            break;
+          case VisualizerType.Binary:
+            _binaryVisualizer = new Visualizer<BinaryEvent>(_source.WriteSourceWithHighlight,
+                                                            WriteEvent);
+            break;
+          case VisualizerType.Comparison:
+            _comparisonVisualizer = new Visualizer<ComparisonEvent>(
+                _source.WriteSourceWithHighlight, WriteEvent);
+            break;
+          case VisualizerType.Eval:
+            _evalVisualizer = new Visualizer<EvalEvent>(_source.WriteSourceWithHighlight,
+                                                        WriteEvent);
+            break;
+          default:
+            throw new NotImplementedException($"Unsupported visualizer type: {type}.");
+        }
+      }
+    }
+
+    internal void RegisterToExecutor(Executor executor) {
+      RegisterToExecutor(executor, _assignmentVisualizer);
+      RegisterToExecutor(executor, _binaryVisualizer);
+      RegisterToExecutor(executor, _comparisonVisualizer);
+      RegisterToExecutor(executor, _evalVisualizer);
+    }
+
+    internal void UnregisterFromExecutor(Executor executor) {
+      UnregisterFromExecutor(executor, _assignmentVisualizer);
+      UnregisterFromExecutor(executor, _binaryVisualizer);
+      UnregisterFromExecutor(executor, _comparisonVisualizer);
+      UnregisterFromExecutor(executor, _evalVisualizer);
+    }
+
+    private static void RegisterToExecutor<Event>(Executor executor,
+                                                  IVisualizer<Event> visualizer) {
+      if (!(visualizer is null)) {
+        executor.Register(visualizer);
+      }
+    }
+
+    private static void UnregisterFromExecutor<Event>(Executor executor,
+                                                      IVisualizer<Event> visualizer) {
+      if (!(visualizer is null)) {
+        executor.Unregister(visualizer);
+      }
+    }
+
+    private void WriteEvent(AbstractEvent e) {
+      switch (e) {
+        case AssignmentEvent ae:
+          Console.WriteLine($"{ae.Identifier} = {ae.Value}");
+          break;
+        case BinaryEvent be:
+          Console.WriteLine($"{be.Left} {_binaryOperatorStrings[be.Op]} {be.Right} = {be.Result}");
+          break;
+        case ComparisonEvent ce:
+          Console.Write($"{ce.First} ");
+          for (int i = 0; i < ce.Ops.Length; ++i) {
+            string exprString = ce.Values[i] is IValue value ? value.String : "?";
+            Console.Write($"{_comparisonOperatorStrings[ce.Ops[i]]} {exprString} ");
+          }
+          Console.WriteLine($"= {ce.Result}");
+          break;
+        case EvalEvent ee:
+          Console.WriteLine($"Eval result: {ee.Value}");
+          break;
+        default:
+          throw new NotImplementedException($"Unsupported event: {e}");
+      }
+    }
+  }
+}

--- a/csharp/tests/SeedLang.Tests/X/SeedPythonDentLexerTests.cs
+++ b/csharp/tests/SeedLang.Tests/X/SeedPythonDentLexerTests.cs
@@ -95,6 +95,14 @@ namespace SeedLang.X.Tests {
                   @"[@-1,0:4='while',<7>,1:0]",
                   @"[@-1,6:9='True',<11>,1:6]",
                   @"[@-1,10:10='\n',<44>,1:10]",})]
+
+    [InlineData("1 + 2\n",
+
+                new string[] {
+                  @"[@-1,0:0='1',<39>,1:0]",
+                  @"[@-1,2:2='+',<24>,1:2]",
+                  @"[@-1,4:4='2',<39>,1:4]",
+                  @"[@-1,5:5='\n',<44>,1:5]",})]
     public void TestScanTokens(string source, string[] expectedTokens) {
       var inputStream = new AntlrInputStream(source);
       var lexer = new SeedPythonDentLexer(inputStream);


### PR DESCRIPTION
- Visualizers can be enabled separately, only `Eval` visualizer is enabled by default.
```shell
dotnet run --project src/SeedLang.Shell -- -v All     # enable all visualizers, include Assignment, Binary, Comparison, Eval
dotnet run --project src/SeedLang.Shell -- -v Binary Eval    # enable Binary and Eval visualizers
```

- Input multi-line source code. Please run following code for testing:
```shell
>>> i = 1
>>> sum = 0
>>> while i < 10:
...   sum = sum + i
...   i = i + 1
...
>>> sum
```